### PR TITLE
Add merge_captain-ready GitHub connector helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,43 @@ Outbound methods:
 | Method | GitHub API |
 |---|---|
 | `issues.create_comment` | `POST /repos/{owner}/{repo}/issues/{issue_number}/comments` |
+| `issues.create` | `POST /repos/{owner}/{repo}/issues` |
+| `issues.create_with_template` | Convenience helper over `issues.create` |
 | `issues.update` | `PATCH /repos/{owner}/{repo}/issues/{issue_number}` |
+| `issues.add_labels` | `POST /repos/{owner}/{repo}/issues/{issue_number}/labels` |
+| `pulls.list` | `GET /repos/{owner}/{repo}/pulls` |
+| `pulls.list_with_checks` | GraphQL `repository.pullRequests` query with `mergeStateStatus` and `statusCheckRollup` |
 | `pulls.get` | `GET /repos/{owner}/{repo}/pulls/{pull_number}` |
+| `pulls.merge` | `PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge` |
+| `pulls.merge_safe` | Convenience helper over branch protection, pull details, merge, and optional branch deletion |
 | `pulls.create_review_comment` | `POST /repos/{owner}/{repo}/pulls/{pull_number}/comments` |
 | `pulls.get_diff` | `GET /repos/{owner}/{repo}/pulls/{pull_number}` with a diff `Accept` header |
 | `pulls.list_files` | `GET /repos/{owner}/{repo}/pulls/{pull_number}/files` |
+| `pulls.list_reviews` | `GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews` |
 | `repos.get_content` | `GET /repos/{owner}/{repo}/contents/{path}` |
+| `repos.get_branch_protection` | `GET /repos/{owner}/{repo}/branches/{branch}/protection` |
+| `git.delete_ref` | `DELETE /repos/{owner}/{repo}/git/refs/{ref}` |
 | `check_runs.create` | `POST /repos/{owner}/{repo}/check-runs` |
 | `check_runs.update` | `PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}` |
 | `graphql` | `POST /graphql` |
+
+## Supported methods for managed personas
+
+Managed personas should prefer the named helpers for high-level workflows and
+use `call(method, args)` only for direct method dispatch.
+
+| Persona need | Helper or method | Notes |
+|---|---|---|
+| List open PRs with merge state and CI rollup | `pulls_list_with_checks(owner, repo, state, limit, options)` or `call("pulls.list_with_checks", args)` | Uses GraphQL because `mergeStateStatus` and `statusCheckRollup` are GraphQL PR fields surfaced by `gh pr --json`; the REST list endpoint does not return the same check rollup shape. Returns `number`, `title`, `headRefName`, `baseRefName`, `isDraft`, `mergeStateStatus`, `statusCheckRollup`, and `url`. |
+| Fetch PR details | `call("pulls.get", args)` | REST PR details for a specific PR number. |
+| Merge a PR directly | `call("pulls.merge", args)` | Sends `merge_method`, `sha`, `commit_title`, and `commit_message` through to GitHub's merge endpoint. If `admin_override` is present, the response is annotated with `admin_override_requested`; GitHub still enforces the installation token's permissions. |
+| Merge with branch-protection awareness | `pulls_merge_safe(owner, repo, number, options)` or `call("pulls.merge_safe", args)` | Fetches PR details, checks base branch protection, requires `admin_override` when the branch is protected, merges with the PR head SHA, and optionally deletes the head branch when `delete_branch` is true. |
+| Create conflict/follow-up issues | `issues_create_with_template(owner, repo, template, vars, options)` or `call("issues.create_with_template", args)` | Renders `{{name}}` placeholders in `title` and `body`, then calls `issues.create`. |
+| Update issues | `call("issues.update", args)` | Supports fields accepted by GitHub's issue update endpoint, such as `state`, `title`, `body`, `labels`, `assignees`, and `milestone`. |
+| Add issue or PR labels | `call("issues.add_labels", args)` | Uses the issue-labels endpoint; GitHub models PRs as issues for labels. |
+| Inspect branch protection | `call("repos.get_branch_protection", args)` | Used by `pulls.merge_safe` before admin merges. |
+| List changed files | `call("pulls.list_files", args)` | Used by review/conflict workflows. |
+| List reviews | `call("pulls.list_reviews", args)` | Used by review workflows. |
 
 ## GitHub App setup
 
@@ -124,11 +152,17 @@ setup should use `private_key_secret` so the PEM is resolved through
 
 Required GitHub App permissions depend on the outbound method:
 
-- `issues.create_comment`, `issues.update`: Issues read/write, or Pull requests
-  read/write when commenting on pull requests.
-- `pulls.get`, `pulls.get_diff`, `pulls.list_files`: Pull requests read.
+- `issues.create_comment`, `issues.create`, `issues.create_with_template`,
+  `issues.update`, `issues.add_labels`: Issues read/write, or Pull requests
+  read/write when acting on pull requests.
+- `pulls.list`, `pulls.list_with_checks`, `pulls.get`, `pulls.get_diff`,
+  `pulls.list_files`, `pulls.list_reviews`: Pull requests read.
+- `pulls.merge`, `pulls.merge_safe`: Pull requests write, and administrator or
+  bypass permissions when merging protected branches.
 - `pulls.create_review_comment`: Pull requests write.
 - `repos.get_content`: Contents read.
+- `repos.get_branch_protection`: Administration read.
+- `git.delete_ref`: Contents write.
 - `check_runs.create`, `check_runs.update`: Checks read/write.
 - `graphql`: the installed app must have the permissions required by the query
   or mutation.

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -8,12 +8,22 @@ let GITHUB_USER_AGENT = "harn-github-connector"
 
 let GITHUB_OUTBOUND_METHODS = [
   "issues.create_comment",
+  "issues.create",
+  "issues.create_with_template",
   "issues.update",
+  "issues.add_labels",
+  "pulls.list",
+  "pulls.list_with_checks",
   "pulls.get",
+  "pulls.merge",
+  "pulls.merge_safe",
   "pulls.create_review_comment",
   "pulls.get_diff",
   "pulls.list_files",
+  "pulls.list_reviews",
   "repos.get_content",
+  "repos.get_branch_protection",
+  "git.delete_ref",
   "check_runs.create",
   "check_runs.update",
   "graphql",
@@ -165,6 +175,17 @@ pub fn call(method, args = {}) {
       cfg,
     )
   }
+  if method == "issues.create" {
+    return __github_json(
+      "POST",
+      __github_api_url(cfg.api_base_url, "/repos/" + args.owner + "/" + args.repo + "/issues"),
+      __body_without(args, __config_keys() + ["owner", "repo"]),
+      cfg,
+    )
+  }
+  if method == "issues.create_with_template" {
+    return __issues_create_with_template(args, cfg)
+  }
   if method == "issues.update" {
     return __github_json(
       "PATCH",
@@ -176,6 +197,32 @@ pub fn call(method, args = {}) {
       cfg,
     )
   }
+  if method == "issues.add_labels" {
+    return __github_json(
+      "POST",
+      __github_api_url(
+        cfg.api_base_url,
+        "/repos/" + args.owner + "/" + args.repo + "/issues/" + to_string(args.issue_number)
+          + "/labels",
+      ),
+      {labels: args.labels ?? []},
+      cfg,
+    )
+  }
+  if method == "pulls.list" {
+    return __github_json(
+      "GET",
+      __github_api_url(
+        cfg.api_base_url,
+        "/repos/" + args.owner + "/" + args.repo + "/pulls" + __pulls_list_query(args),
+      ),
+      nil,
+      cfg,
+    )
+  }
+  if method == "pulls.list_with_checks" {
+    return __pulls_list_with_checks(args, cfg)
+  }
   if method == "pulls.get" {
     return __github_json(
       "GET",
@@ -186,6 +233,28 @@ pub fn call(method, args = {}) {
       nil,
       cfg,
     )
+  }
+  if method == "pulls.merge" {
+    let merged = __github_json(
+      "PUT",
+      __github_api_url(
+        cfg.api_base_url,
+        "/repos/" + args.owner + "/" + args.repo + "/pulls/" + to_string(args.pull_number)
+          + "/merge",
+      ),
+      __body_without(
+        args,
+        __config_keys() + ["owner", "repo", "pull_number", "admin_override", "delete_branch"],
+      ),
+      cfg,
+    )
+    if is_err(merged) {
+      return merged
+    }
+    return __merge_annotation(merged, args)
+  }
+  if method == "pulls.merge_safe" {
+    return __pulls_merge_safe(args, cfg)
   }
   if method == "pulls.create_review_comment" {
     return __github_json(
@@ -223,6 +292,19 @@ pub fn call(method, args = {}) {
       cfg,
     )
   }
+  if method == "pulls.list_reviews" {
+    return __github_json(
+      "GET",
+      __github_api_url(
+        cfg.api_base_url,
+        "/repos/" + args.owner + "/" + args.repo + "/pulls/" + to_string(args.pull_number)
+          + "/reviews"
+          + __pagination_query(args),
+      ),
+      nil,
+      cfg,
+    )
+  }
   if method == "repos.get_content" {
     return __github_json(
       "GET",
@@ -231,6 +313,30 @@ pub fn call(method, args = {}) {
         "/repos/" + args.owner + "/" + args.repo + "/contents/"
           + __trim_leading_slash(args.path ?? "")
           + __ref_query(args),
+      ),
+      nil,
+      cfg,
+    )
+  }
+  if method == "repos.get_branch_protection" {
+    return __github_json(
+      "GET",
+      __github_api_url(
+        cfg.api_base_url,
+        "/repos/" + args.owner + "/" + args.repo + "/branches/" + url_encode(to_string(args.branch))
+          + "/protection",
+      ),
+      nil,
+      cfg,
+    )
+  }
+  if method == "git.delete_ref" {
+    return __github_json(
+      "DELETE",
+      __github_api_url(
+        cfg.api_base_url,
+        "/repos/" + args.owner + "/" + args.repo + "/git/refs/"
+          + __trim_leading_slash(args.ref ?? ""),
       ),
       nil,
       cfg,
@@ -259,6 +365,321 @@ pub fn call(method, args = {}) {
     "POST",
     __github_api_url(cfg.api_base_url, "/graphql"),
     {query: args.query, variables: args.variables ?? {}},
+    cfg,
+  )
+}
+
+/** List PRs in the same shape consumed by managed merge_captain. */
+pub fn pulls_list_with_checks(owner, repo, state = "open", limit = 100, options = nil) {
+  let opts = options ?? {}
+  return call("pulls.list_with_checks", opts + {owner: owner, repo: repo, state: state, limit: limit})
+}
+
+/** Merge a PR after checking the base branch protection settings. */
+pub fn pulls_merge_safe(owner, repo, number, options = nil) {
+  let opts = options ?? {}
+  return call("pulls.merge_safe", opts + {owner: owner, repo: repo, pull_number: number})
+}
+
+/** Create an issue from a small title/body template and variables. */
+pub fn issues_create_with_template(owner, repo, template, vars = nil, options = nil) {
+  let opts = options ?? {}
+  return call(
+    "issues.create_with_template",
+    opts + {owner: owner, repo: repo, template: template, vars: vars ?? {}},
+  )
+}
+
+fn __issues_create_with_template(args, cfg) {
+  let template = args?.template ?? {}
+  let title_template = if type_of(template) == "dict" {
+    template?.title ?? args?.title_template ?? args?.title ?? "Merge Captain follow-up"
+  } else {
+    args?.title_template ?? args?.title ?? "Merge Captain follow-up"
+  }
+  let body_template = if type_of(template) == "dict" {
+    template?.body ?? args?.body_template ?? ""
+  } else {
+    to_string(template)
+  }
+  var body = {
+    title: __render_template(title_template, args?.vars ?? {}),
+    body: __render_template(body_template, args?.vars ?? {}),
+  }
+  let labels = args?.labels ?? if type_of(template) == "dict" {
+    template?.labels
+  } else {
+    nil
+  }
+  if labels != nil {
+    body["labels"] = labels
+  }
+  let assignees = args?.assignees ?? if type_of(template) == "dict" {
+    template?.assignees
+  } else {
+    nil
+  }
+  if assignees != nil {
+    body["assignees"] = assignees
+  }
+  let milestone = args?.milestone ?? if type_of(template) == "dict" {
+    template?.milestone
+  } else {
+    nil
+  }
+  if milestone != nil {
+    body["milestone"] = milestone
+  }
+  return __github_json(
+    "POST",
+    __github_api_url(cfg.api_base_url, "/repos/" + args.owner + "/" + args.repo + "/issues"),
+    body,
+    cfg,
+  )
+}
+
+fn __pulls_list_with_checks(args, cfg) {
+  let graph = __github_json(
+    "POST",
+    __github_api_url(cfg.api_base_url, "/graphql"),
+    {
+      query: __pulls_with_checks_query(),
+      variables: {
+        owner: args.owner,
+        repo: args.repo,
+        states: [uppercase(args?.state ?? "OPEN")],
+        limit: min(max(to_int(args?.limit ?? 100) ?? 100, 1), 100),
+        checkLimit: min(max(to_int(args?.check_limit ?? 50) ?? 50, 1), 100),
+      },
+    },
+    cfg,
+  )
+  if is_err(graph) {
+    return graph
+  }
+  let payload = graph
+  if payload?.errors != nil && len(payload.errors) > 0 {
+    return __err("graphql", "github GraphQL returned errors: " + json_stringify(payload.errors))
+  }
+  let nodes = payload?.data?.repository?.pullRequests?.nodes ?? []
+  var pulls = []
+  for node in nodes {
+    pulls = pulls + [__normalize_graphql_pr(node)]
+  }
+  return pulls
+}
+
+fn __pulls_merge_safe(args, cfg) {
+  let pull = __github_json(
+    "GET",
+    __github_api_url(
+      cfg.api_base_url,
+      "/repos/" + args.owner + "/" + args.repo + "/pulls/" + to_string(args.pull_number),
+    ),
+    nil,
+    cfg,
+  )
+  if is_err(pull) {
+    return pull
+  }
+  let base_branch = pull?.base?.ref ?? args?.base_branch
+  let protection = __github_json(
+    "GET",
+    __github_api_url(
+      cfg.api_base_url,
+      "/repos/" + args.owner + "/" + args.repo + "/branches/" + url_encode(to_string(base_branch))
+        + "/protection",
+    ),
+    nil,
+    cfg,
+  )
+  let protected = !is_err(protection)
+  if is_err(protection) && !contains(to_string(unwrap_err(protection)?.message ?? ""), "status 404") {
+    return protection
+  }
+  if protected && !(args?.admin_override ?? false) {
+    return __err(
+      "protected_branch_requires_admin_override",
+      "base branch `" + to_string(base_branch)
+        + "` is protected; pass admin_override to merge through it",
+    )
+  }
+  let merged = __github_json(
+    "PUT",
+    __github_api_url(
+      cfg.api_base_url,
+      "/repos/" + args.owner + "/" + args.repo + "/pulls/" + to_string(args.pull_number) + "/merge",
+    ),
+    __merge_body(args, pull),
+    cfg,
+  )
+  if is_err(merged) {
+    return merged
+  }
+  var result = {
+    pull_request: pull,
+    protected: protected,
+    branch_protection: if protected {
+      protection
+    } else {
+      nil
+    },
+    merge: __merge_annotation(merged, args),
+  }
+  if args?.delete_branch ?? false {
+    let deleted = __delete_pull_head_branch(args, pull, cfg)
+    if is_err(deleted) {
+      return deleted
+    }
+    result["delete_branch"] = deleted
+  }
+  return result
+}
+
+fn __render_template(template, vars) {
+  var rendered = to_string(template ?? "")
+  for entry in (vars ?? {}).entries() {
+    let value = to_string(entry.value ?? "")
+    rendered = rendered.replace("{{" + to_string(entry.key) + "}}", value)
+    rendered = rendered.replace("${" + to_string(entry.key) + "}", value)
+  }
+  return rendered
+}
+
+fn __pulls_with_checks_query() {
+  return """
+query HarnGithubConnectorPullsWithChecks($owner: String!, $repo: String!, $states: [PullRequestState!], $limit: Int!, $checkLimit: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(states: $states, first: $limit, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes {
+        number
+        title
+        headRefName
+        baseRefName
+        isDraft
+        mergeStateStatus
+        url
+        statusCheckRollup {
+          contexts(first: $checkLimit) {
+            nodes {
+              __typename
+              ... on CheckRun {
+                name
+                status
+                conclusion
+                detailsUrl
+              }
+              ... on StatusContext {
+                context
+                state
+                targetUrl
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+}
+
+fn __normalize_graphql_pr(node) {
+  return {
+    number: node?.number,
+    title: node?.title ?? "",
+    headRefName: node?.headRefName ?? "",
+    baseRefName: node?.baseRefName ?? "",
+    isDraft: node?.isDraft ?? false,
+    mergeStateStatus: node?.mergeStateStatus ?? "UNKNOWN",
+    statusCheckRollup: __normalize_status_check_rollup(node?.statusCheckRollup),
+    url: node?.url ?? "",
+  }
+}
+
+fn __normalize_status_check_rollup(rollup) {
+  let contexts = rollup?.contexts?.nodes ?? []
+  var checks = []
+  for context in contexts {
+    checks = checks + [__normalize_status_check(context)]
+  }
+  return checks
+}
+
+fn __normalize_status_check(context) {
+  if context?.__typename == "StatusContext" {
+    let state = uppercase(context?.state ?? "")
+    return {
+      name: context?.context ?? "",
+      status: if state == "PENDING" {
+        "IN_PROGRESS"
+      } else {
+        "COMPLETED"
+      },
+      conclusion: __status_context_conclusion(state),
+      detailsUrl: context?.targetUrl,
+    }
+  }
+  return {
+    name: context?.name ?? "",
+    status: context?.status ?? "",
+    conclusion: context?.conclusion,
+    detailsUrl: context?.detailsUrl,
+  }
+}
+
+fn __status_context_conclusion(state) {
+  if state == "SUCCESS" {
+    return "SUCCESS"
+  }
+  if state == "FAILURE" || state == "ERROR" {
+    return state
+  }
+  return nil
+}
+
+fn __merge_body(args, pull) {
+  var body = __body_without(
+    args,
+    __config_keys()
+      + [
+      "owner",
+      "repo",
+      "pull_number",
+      "admin_override",
+      "delete_branch",
+      "base_branch",
+      "check_branch_protection",
+    ],
+  )
+  if body?.sha == nil && pull?.head?.sha != nil {
+    body["sha"] = pull.head.sha
+  }
+  return body
+}
+
+fn __merge_annotation(response, args) {
+  if args?.admin_override ?? false {
+    return response + {admin_override_requested: true}
+  }
+  return response
+}
+
+fn __delete_pull_head_branch(args, pull, cfg) {
+  let head_ref = pull?.head?.ref
+  if head_ref == nil || trim(to_string(head_ref)) == "" {
+    return __err("missing_head_ref", "cannot delete PR branch because pull.head.ref was missing")
+  }
+  let head_repo = pull?.head?.repo
+  let repo_owner = head_repo?.owner?.login ?? args.owner
+  let repo_name = head_repo?.name ?? args.repo
+  return __github_json(
+    "DELETE",
+    __github_api_url(
+      cfg.api_base_url,
+      "/repos/" + repo_owner + "/" + repo_name + "/git/refs/heads/" + to_string(head_ref),
+    ),
+    nil,
     cfg,
   )
 }
@@ -679,6 +1100,35 @@ fn __pagination_query(args) {
   var parts = []
   if args?.per_page != nil {
     parts = parts + ["per_page=" + url_encode(to_string(args.per_page))]
+  }
+  if args?.page != nil {
+    parts = parts + ["page=" + url_encode(to_string(args.page))]
+  }
+  if len(parts) == 0 {
+    return ""
+  }
+  return "?" + join(parts, "&")
+}
+
+fn __pulls_list_query(args) {
+  var parts = []
+  if args?.state != nil {
+    parts = parts + ["state=" + url_encode(to_string(args.state))]
+  }
+  if args?.head != nil {
+    parts = parts + ["head=" + url_encode(to_string(args.head))]
+  }
+  if args?.base != nil {
+    parts = parts + ["base=" + url_encode(to_string(args.base))]
+  }
+  if args?.sort != nil {
+    parts = parts + ["sort=" + url_encode(to_string(args.sort))]
+  }
+  if args?.direction != nil {
+    parts = parts + ["direction=" + url_encode(to_string(args.direction))]
+  }
+  if args?.per_page != nil || args?.limit != nil {
+    parts = parts + ["per_page=" + url_encode(to_string(args?.per_page ?? args?.limit))]
   }
   if args?.page != nil {
     parts = parts + ["page=" + url_encode(to_string(args.page))]

--- a/tests/merge_captain_methods.harn
+++ b/tests/merge_captain_methods.harn
@@ -1,0 +1,256 @@
+import {
+  call,
+  issues_create_with_template,
+  pulls_list_with_checks,
+  pulls_merge_safe,
+} from "../src/lib"
+
+pipeline default() {
+  http_mock_clear()
+  let base = "https://github-api.test"
+  let token = "github-installation-token"
+  let auth = {api_base_url: base, installation_token: token}
+  http_mock(
+    "POST",
+    base + "/graphql",
+    {
+      status: 200,
+      body: json_stringify(
+        {
+          data: {
+            repository: {
+              pullRequests: {
+                nodes: [
+                  {
+                    number: 101,
+                    title: "Ship release notes",
+                    headRefName: "release/notes",
+                    baseRefName: "main",
+                    isDraft: false,
+                    mergeStateStatus: "CLEAN",
+                    url: "https://github.com/octo-org/octo-repo/pull/101",
+                    statusCheckRollup: {
+                      contexts: {
+                        nodes: [
+                          {
+                            __typename: "CheckRun",
+                            name: "Harn CI",
+                            status: "COMPLETED",
+                            conclusion: "SUCCESS",
+                            detailsUrl: "https://github.com/octo-org/octo-repo/actions/runs/1",
+                          },
+                          {
+                            __typename: "StatusContext",
+                            context: "legacy/status",
+                            state: "SUCCESS",
+                            targetUrl: "https://ci.example.test/101",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ),
+      headers: {["x-ratelimit-remaining"]: "10"},
+    },
+  )
+  let pulls = pulls_list_with_checks("octo-org", "octo-repo", "open", 2, auth)
+  assert_eq(pulls[0].number, 101, "list_with_checks PR number")
+  assert_eq(pulls[0].mergeStateStatus, "CLEAN", "list_with_checks merge state")
+  assert_eq(pulls[0].statusCheckRollup[0].conclusion, "SUCCESS", "check run conclusion")
+  assert_eq(pulls[0].statusCheckRollup[1].status, "COMPLETED", "status context normalized")
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/pulls?state=open&per_page=3",
+    {
+      status: 200,
+      body: json_stringify([{number: 101}, {number: 102}]),
+      headers: {["x-ratelimit-remaining"]: "9"},
+    },
+  )
+  let rest_pulls = call("pulls.list", auth + {owner: "octo-org", repo: "octo-repo", state: "open", limit: 3})
+  assert_eq(len(rest_pulls), 2, "pulls.list response")
+  http_mock(
+    "POST",
+    base + "/repos/octo-org/octo-repo/issues",
+    {
+      status: 201,
+      body: json_stringify({number: 77, title: "Conflict in #101"}),
+      headers: {["x-ratelimit-remaining"]: "8"},
+    },
+  )
+  let issue = issues_create_with_template(
+    "octo-org",
+    "octo-repo",
+    {
+      title: "Conflict in #{{number}}",
+      body: "PR {{number}} needs a human for {{reason}}.",
+      labels: ["merge-captain", "needs-human"],
+    },
+    {number: 101, reason: "semantic conflict"},
+    auth,
+  )
+  assert_eq(issue.number, 77, "template issue number")
+  http_mock(
+    "PATCH",
+    base + "/repos/octo-org/octo-repo/issues/77",
+    {
+      status: 200,
+      body: json_stringify({number: 77, state: "closed"}),
+      headers: {["x-ratelimit-remaining"]: "7"},
+    },
+  )
+  call(
+    "issues.update",
+    auth + {owner: "octo-org", repo: "octo-repo", issue_number: 77, state: "closed"},
+  )
+  http_mock(
+    "POST",
+    base + "/repos/octo-org/octo-repo/issues/77/labels",
+    {
+      status: 200,
+      body: json_stringify([{name: "merge-captain"}]),
+      headers: {["x-ratelimit-remaining"]: "6"},
+    },
+  )
+  let labels = call(
+    "issues.add_labels",
+    auth + {owner: "octo-org", repo: "octo-repo", issue_number: 77, labels: ["merge-captain"]},
+  )
+  assert_eq(labels[0].name, "merge-captain", "add labels response")
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/branches/develop/protection",
+    {
+      status: 200,
+      body: json_stringify({required_status_checks: {strict: true}}),
+      headers: {["x-ratelimit-remaining"]: "5"},
+    },
+  )
+  let protection = call(
+    "repos.get_branch_protection",
+    auth + {owner: "octo-org", repo: "octo-repo", branch: "develop"},
+  )
+  assert(protection.required_status_checks.strict, "branch protection response")
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/pulls/101/files?per_page=2",
+    {
+      status: 200,
+      body: json_stringify([{filename: "src/lib.harn"}]),
+      headers: {["x-ratelimit-remaining"]: "4"},
+    },
+  )
+  let files = call(
+    "pulls.list_files",
+    auth + {owner: "octo-org", repo: "octo-repo", pull_number: 101, per_page: 2},
+  )
+  assert_eq(files[0].filename, "src/lib.harn", "list files response")
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/pulls/101/reviews?per_page=2",
+    {
+      status: 200,
+      body: json_stringify([{id: 9001, state: "APPROVED"}]),
+      headers: {["x-ratelimit-remaining"]: "3"},
+    },
+  )
+  let reviews = call(
+    "pulls.list_reviews",
+    auth + {owner: "octo-org", repo: "octo-repo", pull_number: 101, per_page: 2},
+  )
+  assert_eq(reviews[0].state, "APPROVED", "list reviews response")
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/pulls/101",
+    {
+      status: 200,
+      body: json_stringify(
+        {
+          number: 101,
+          base: {ref: "main"},
+          head: {
+            sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            ref: "feature/mergeable",
+            repo: {name: "octo-repo", owner: {login: "octo-org"}},
+          },
+        },
+      ),
+      headers: {["x-ratelimit-remaining"]: "2"},
+    },
+  )
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/branches/main/protection",
+    {
+      status: 200,
+      body: json_stringify({required_status_checks: {strict: true}}),
+      headers: {["x-ratelimit-remaining"]: "2"},
+    },
+  )
+  http_mock(
+    "PUT",
+    base + "/repos/octo-org/octo-repo/pulls/101/merge",
+    {
+      status: 200,
+      body: json_stringify({merged: true, message: "Pull Request successfully merged"}),
+      headers: {["x-ratelimit-remaining"]: "2"},
+    },
+  )
+  http_mock(
+    "DELETE",
+    base + "/repos/octo-org/octo-repo/git/refs/heads/feature/mergeable",
+    {status: 204, body: "", headers: {["x-ratelimit-remaining"]: "2"}},
+  )
+  let merged = pulls_merge_safe(
+    "octo-org",
+    "octo-repo",
+    101,
+    auth + {merge_method: "squash", admin_override: true, delete_branch: true},
+  )
+  assert(merged.protected, "merge_safe detected protected branch")
+  assert(merged.merge.merged, "merge_safe merge response")
+  assert(merged.merge.admin_override_requested, "merge_safe admin override annotation")
+  assert_eq(merged.delete_branch.status, 204, "merge_safe deleted branch")
+  http_mock(
+    "PUT",
+    base + "/repos/octo-org/octo-repo/pulls/102/merge",
+    {status: 200, body: json_stringify({merged: true}), headers: {["x-ratelimit-remaining"]: "2"}},
+  )
+  let direct_merge = call(
+    "pulls.merge",
+    auth + {owner: "octo-org", repo: "octo-repo", pull_number: 102, merge_method: "merge"},
+  )
+  assert(direct_merge.merged, "pulls.merge response")
+  let calls = http_mock_calls()
+  assert_eq(calls[0].url, base + "/graphql", "list_with_checks uses GraphQL")
+  assert_eq(json_parse(calls[0].body).variables.limit, 2, "GraphQL limit variable")
+  assert(
+    contains(json_parse(calls[0].body).query, "mergeStateStatus"),
+    "GraphQL query includes merge state",
+  )
+  assert(
+    contains(json_parse(calls[0].body).query, "statusCheckRollup"),
+    "GraphQL query includes checks",
+  )
+  assert_eq(json_parse(calls[2].body).title, "Conflict in #101", "template title rendered")
+  assert_eq(
+    json_parse(calls[2].body).body,
+    "PR 101 needs a human for semantic conflict.",
+    "template body rendered",
+  )
+  assert_eq(json_parse(calls[4].body).labels[0], "merge-captain", "labels request body")
+  assert_eq(json_parse(calls[10].body).merge_method, "squash", "merge_safe merge method")
+  assert_eq(
+    json_parse(calls[10].body).sha,
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "merge_safe expected SHA",
+  )
+  assert_eq(json_parse(calls[12].body).merge_method, "merge", "pulls.merge body")
+  assert_eq(calls[0].headers.authorization, "[redacted]", "authorization header redacted")
+  http_mock_clear()
+}


### PR DESCRIPTION
## Summary
- add merge_captain/review_captain dispatcher coverage for PR listing, merging, reviews, issues, labels, branch protection, and ref deletion
- add named helpers for PRs with checks, protected-branch-aware merge, and templated issue creation
- document the managed persona method matrix and GitHub App permissions
- add mocked fixture coverage for the helper steel thread and new methods

Closes #19.

## Verification
- harn check src/lib.harn
- harn lint src/lib.harn
- harn fmt --check src tests
- harn connector check . --provider github
- for test in tests/*.harn; do harn run "" || exit 1; done
- harn test conformance --filter github_connector_merge_captain_methods (from /Users/ksinder/projects/harn; returned 0 total because that upstream conformance filter is not present locally)

## Self-review
- re-read the formatted diff after tests and tightened ambiguous helper argument merging before commit
- checked the GraphQL helper returns the exact merge_captain classification fields: number, title, head/base refs, draft state, mergeStateStatus, statusCheckRollup, and URL
- kept all outbound calls on the existing installation-token request path so auth redaction, 401 refresh, and rate-limit behavior remain shared