### PR TITLE
[codex] Implement GitHub webhook event normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,39 @@ Inbound webhooks:
 - `workflow_run`
 - `deployment_status`
 - `check_run`
+- `check_suite`
+- `status`
+- `merge_group`
+- `installation`
+- `installation_repositories`
+
+Normalized webhook payloads use a stable provider envelope:
+
+| Field | Notes |
+|---|---|
+| `provider` | Always `github`. |
+| `event` | GitHub webhook event kind, such as `pull_request` or `merge_group`. |
+| `topic` | Stable subscription topic in the form `github.<event>` or `github.<event>.<action>`. |
+| `action` | GitHub payload action when present. |
+| `delivery_id` | `X-GitHub-Delivery`, also used for the event dedupe key. |
+| `installation_id` | GitHub App installation id when present. |
+| `repository` / `repo` | Raw repository object plus normalized `{owner, name, full_name}`. |
+| `raw` | Original GitHub payload for fields not promoted by the connector. |
+
+Merge Captain and release workflow consumers should subscribe to these stable
+topics:
+
+| Topic | Promoted fields |
+|---|---|
+| `github.pull_request.<action>` | `pull_request`, `pull_request_number`, `head_sha`, `head_ref`, `base_sha`, `base_ref`, `draft`, `merged`, `labels` |
+| `github.check_run.<action>` | `check_run`, `check_id`, `check_run_id`, `check_suite_id`, `pull_request_number`, `head_sha`, `head_ref`, `base_ref`, `name`, `status`, `conclusion` |
+| `github.check_suite.<action>` | `check_suite`, `check_suite_id`, `pull_request_number`, `head_sha`, `head_ref`, `base_ref`, `status`, `conclusion` |
+| `github.workflow_run.<action>` | `workflow_run`, `run_id`, `run_number`, `workflow_id`, `check_suite_id`, `pull_request_number`, `head_sha`, `head_ref`, `base_ref`, `name`, `status`, `conclusion` |
+| `github.status` | `commit_status`, `status_id`, `head_sha`, `head_ref`, `base_ref`, `state`, `context`, `target_url` |
+| `github.merge_group.<action>` | `merge_group`, `merge_group_id`, `head_sha`, `head_ref`, `base_sha`, `base_ref`, `pull_requests`, `pull_request_numbers` |
+| `github.push` | `ref`, `ref_name`, `before`, `after`, `head_sha`, `head_ref`, `commits`, `distinct_size`, `head_commit`, `pusher`, `created`, `deleted`, `forced` |
+| `github.installation.<action>` | `installation`, `account`, `installation_state`, `suspended`, `revoked`, `repositories` |
+| `github.installation_repositories.<action>` | `installation`, `account`, `installation_state`, `suspended`, `revoked`, `repository_selection`, `repositories_added`, `repositories_removed` |
 
 Outbound methods:
 

--- a/harn.toml
+++ b/harn.toml
@@ -134,6 +134,84 @@ expect_event_count = 1
 
 [[connector_contract.fixtures]]
 provider = "github"
+name = "check suite requested webhook"
+kind = "webhook"
+headers = { "X-GitHub-Event" = "check_suite", "X-GitHub-Delivery" = "delivery-contract-check-suite-requested", "X-Hub-Signature-256" = "sha256=ebca4fa04e40e59bb15606ceb8ded0b1ad447974cc094ff6a125236b8f461067", "content-type" = "application/json" }
+metadata = { signing_secret = "test-signing-secret" }
+body = '''{"action":"requested","check_suite":{"id":8101,"status":"queued","conclusion":null,"head_branch":"feature/connector-fixture","head_sha":"cccccccccccccccccccccccccccccccccccccccc","pull_requests":[{"number":42,"head":{"ref":"feature/connector-fixture","sha":"cccccccccccccccccccccccccccccccccccccccc"},"base":{"ref":"main","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}],"created_at":"2026-04-20T15:59:00Z","updated_at":"2026-04-20T15:59:00Z"},"repository":{"name":"octo-repo","full_name":"octo-org/octo-repo","owner":{"id":2001,"login":"octo-org","type":"Organization"}},"sender":{"id":1001,"login":"octocat","type":"User"},"installation":{"id":3001}}'''
+expect_type = "event"
+expect_kind = "check_suite"
+expect_signature_state = "verified"
+expect_payload_contains = { provider = "github", event = "check_suite", action = "requested", installation_id = 3001 }
+expect_event_count = 1
+
+[[connector_contract.fixtures]]
+provider = "github"
+name = "status success webhook"
+kind = "webhook"
+headers = { "X-GitHub-Event" = "status", "X-GitHub-Delivery" = "delivery-contract-status-success", "X-Hub-Signature-256" = "sha256=872533387fc2c4e2e11681288d212c716c3a5fe35e7771b6ec6ba034709993b8", "content-type" = "application/json" }
+metadata = { signing_secret = "test-signing-secret" }
+body = '''{"id":9101,"sha":"cccccccccccccccccccccccccccccccccccccccc","state":"success","context":"legacy/status","target_url":"https://ci.example.test/octo-repo/9101","description":"Legacy CI passed","branches":[{"name":"main"}],"created_at":"2026-04-20T16:05:00Z","updated_at":"2026-04-20T16:05:00Z","repository":{"name":"octo-repo","full_name":"octo-org/octo-repo","owner":{"id":2001,"login":"octo-org","type":"Organization"}},"sender":{"id":1001,"login":"octocat","type":"User"},"installation":{"id":3001}}'''
+expect_type = "event"
+expect_kind = "status"
+expect_signature_state = "verified"
+expect_payload_contains = { provider = "github", event = "status", installation_id = 3001 }
+expect_event_count = 1
+
+[[connector_contract.fixtures]]
+provider = "github"
+name = "merge group checks requested webhook"
+kind = "webhook"
+headers = { "X-GitHub-Event" = "merge_group", "X-GitHub-Delivery" = "delivery-contract-merge-group-checks-requested", "X-Hub-Signature-256" = "sha256=e9a802a5469f1cd73c92a06b26d5f18e71689381c172184a3817380fe145c98f", "content-type" = "application/json" }
+metadata = { signing_secret = "test-signing-secret" }
+body = '''{"action":"checks_requested","merge_group":{"id":9201,"head_ref":"gh-readonly-queue/main/pr-42-cccccccccccc","head_sha":"dddddddddddddddddddddddddddddddddddddddd","base_ref":"main","base_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_commit":{"timestamp":"2026-04-20T16:06:00Z"},"pull_requests":[{"number":42,"head":{"ref":"feature/connector-fixture","sha":"cccccccccccccccccccccccccccccccccccccccc"},"base":{"ref":"main","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}]},"repository":{"name":"octo-repo","full_name":"octo-org/octo-repo","owner":{"id":2001,"login":"octo-org","type":"Organization"}},"sender":{"id":1001,"login":"octocat","type":"User"},"installation":{"id":3001}}'''
+expect_type = "event"
+expect_kind = "merge_group"
+expect_signature_state = "verified"
+expect_payload_contains = { provider = "github", event = "merge_group", action = "checks_requested", installation_id = 3001 }
+expect_event_count = 1
+
+[[connector_contract.fixtures]]
+provider = "github"
+name = "installation suspend webhook"
+kind = "webhook"
+headers = { "X-GitHub-Event" = "installation", "X-GitHub-Delivery" = "delivery-contract-installation-suspend", "X-Hub-Signature-256" = "sha256=67cab28a2624f01d86151e5a87cc667436d4931387b95d51c27660d22b8c46da", "content-type" = "application/json" }
+metadata = { signing_secret = "test-signing-secret" }
+body = '''{"action":"suspend","installation":{"id":3001,"account":{"id":2001,"login":"octo-org","type":"Organization"},"repository_selection":"selected","suspended_at":"2026-04-20T18:00:00Z","suspended_by":{"id":1003,"login":"admin","type":"User"}},"repositories":[{"id":4001,"name":"octo-repo","full_name":"octo-org/octo-repo","private":false}],"sender":{"id":1003,"login":"admin","type":"User"}}'''
+expect_type = "event"
+expect_kind = "installation"
+expect_signature_state = "verified"
+expect_payload_contains = { provider = "github", event = "installation", action = "suspend", installation_id = 3001 }
+expect_event_count = 1
+
+[[connector_contract.fixtures]]
+provider = "github"
+name = "installation deleted webhook"
+kind = "webhook"
+headers = { "X-GitHub-Event" = "installation", "X-GitHub-Delivery" = "delivery-contract-installation-deleted", "X-Hub-Signature-256" = "sha256=74b770dbd0897fc170100b27f14b5018ad9049cffe395364a54c6f74a5ce7375", "content-type" = "application/json" }
+metadata = { signing_secret = "test-signing-secret" }
+body = '''{"action":"deleted","installation":{"id":3001,"account":{"id":2001,"login":"octo-org","type":"Organization"},"repository_selection":"selected"},"repositories":[{"id":4001,"name":"octo-repo","full_name":"octo-org/octo-repo","private":false}],"sender":{"id":1003,"login":"admin","type":"User"}}'''
+expect_type = "event"
+expect_kind = "installation"
+expect_signature_state = "verified"
+expect_payload_contains = { provider = "github", event = "installation", action = "deleted", installation_id = 3001 }
+expect_event_count = 1
+
+[[connector_contract.fixtures]]
+provider = "github"
+name = "installation repositories removed webhook"
+kind = "webhook"
+headers = { "X-GitHub-Event" = "installation_repositories", "X-GitHub-Delivery" = "delivery-contract-installation-repositories-removed", "X-Hub-Signature-256" = "sha256=6c9518ef23ec3fdc5bb028b07d7c4e74b3ec6c55098dd3ff9eb4e1ad05de250e", "content-type" = "application/json" }
+metadata = { signing_secret = "test-signing-secret" }
+body = '''{"action":"removed","installation":{"id":3001,"account":{"id":2001,"login":"octo-org","type":"Organization"},"repository_selection":"selected"},"repository_selection":"selected","repositories_added":[],"repositories_removed":[{"id":4001,"name":"octo-repo","full_name":"octo-org/octo-repo","private":false}],"sender":{"id":1003,"login":"admin","type":"User"}}'''
+expect_type = "event"
+expect_kind = "installation_repositories"
+expect_signature_state = "verified"
+expect_payload_contains = { provider = "github", event = "installation_repositories", action = "removed", installation_id = 3001 }
+expect_event_count = 1
+
+[[connector_contract.fixtures]]
+provider = "github"
 name = "invalid signature reject"
 kind = "webhook"
 headers = { "X-GitHub-Event" = "issues", "X-GitHub-Delivery" = "delivery-contract-invalid", "X-Hub-Signature-256" = "sha256=0000000000000000000000000000000000000000000000000000000000000000", "content-type" = "application/json" }

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -38,6 +38,11 @@ let GITHUB_WEBHOOK_EVENTS = [
   "workflow_run",
   "deployment_status",
   "check_run",
+  "check_suite",
+  "status",
+  "merge_group",
+  "installation",
+  "installation_repositories",
 ]
 
 let TOKEN_CACHE_KEY = "harn-github-connector.token_cache"
@@ -69,10 +74,22 @@ pub fn payload_schema() {
       required: ["event", "raw"],
       additionalProperties: true,
       properties: {
+        provider: {type: "string"},
         event: {type: "string"},
+        topic: {type: "string"},
         action: {type: ["string", "null"]},
         delivery_id: {type: ["string", "null"]},
         installation_id: {type: ["integer", "null"]},
+        repository: {type: ["object", "null"]},
+        repo: {type: ["object", "null"]},
+        pull_request_number: {type: ["integer", "null"]},
+        head_sha: {type: ["string", "null"]},
+        head_ref: {type: ["string", "null"]},
+        base_ref: {type: ["string", "null"]},
+        run_id: {type: ["integer", "null"]},
+        check_id: {type: ["integer", "null"]},
+        check_suite_id: {type: ["integer", "null"]},
+        merge_group_id: {type: ["integer", "null", "string"]},
         raw: {type: "object"},
         issue: {type: ["object", "null"]},
         pull_request: {type: ["object", "null"]},
@@ -83,6 +100,13 @@ pub fn payload_schema() {
         deployment_status: {type: ["object", "null"]},
         deployment: {type: ["object", "null"]},
         check_run: {type: ["object", "null"]},
+        check_suite: {type: ["object", "null"]},
+        status: {type: ["string", "null"]},
+        commit_status: {type: ["object", "null"]},
+        merge_group: {type: ["object", "null"]},
+        installation: {type: ["object", "null"]},
+        repositories_added: {type: ["array", "null"]},
+        repositories_removed: {type: ["array", "null"]},
       },
     },
   }
@@ -929,12 +953,15 @@ fn __build_event(event_kind, payload, raw, headers) {
   let repo = __repo(payload)
   let occurred_at = __occurred_at(event_kind, payload, raw)
   let delivery_id = __header(headers, "x-github-delivery")
+  let normalized_payload = __normalize_github_payload(event_kind, payload, delivery_id)
   return {
     kind: event_kind,
+    topic: normalized_payload.topic,
     occurred_at: occurred_at,
     dedupe_key: __dedupe_key(event_kind, payload, repo, delivery_id),
+    delivery_id: delivery_id,
     signature_status: {state: "verified"},
-    payload: payload,
+    payload: normalized_payload,
     headers: {["x-github-event"]: event_kind, ["x-github-delivery"]: delivery_id},
   }
 }
@@ -957,9 +984,257 @@ fn __dedupe_key(event_kind, payload, repo, delivery_id) {
       ?? payload?.workflow_run?.id
       ?? payload?.deployment_status?.id
       ?? payload?.check_run?.id
+      ?? payload?.check_suite?.id
+      ?? payload?.merge_group?.id
+      ?? payload?.installation?.id
+      ?? payload?.sha
       ?? "",
   )
   return "github:" + event_kind + ":" + repo_part + ":" + to_string(action) + ":" + resource_id
+}
+
+@complexity(allow)
+fn __normalize_github_payload(event_kind, raw, delivery_id) {
+  let common = {
+    provider: GITHUB_PROVIDER_ID,
+    event: event_kind,
+    topic: __topic(event_kind, raw?.action),
+    action: raw?.action,
+    delivery_id: delivery_id,
+    installation_id: raw?.installation?.id,
+    installation: raw?.installation,
+    repository: raw?.repository,
+    repo: __repo(raw),
+    sender: raw?.sender,
+    raw: raw,
+  }
+  if event_kind == "pull_request" {
+    let pr = raw?.pull_request ?? {}
+    return common
+      + {
+      pull_request: pr,
+      pull_request_id: pr?.id,
+      pull_request_number: raw?.number ?? pr?.number,
+      head_sha: pr?.head?.sha,
+      head_ref: pr?.head?.ref,
+      base_sha: pr?.base?.sha,
+      base_ref: pr?.base?.ref,
+      draft: pr?.draft,
+      merged: pr?.merged,
+      labels: pr?.labels ?? [],
+    }
+  }
+  if event_kind == "check_run" {
+    let check = raw?.check_run ?? {}
+    let pr = __first(check?.pull_requests)
+    return common
+      + {
+      check_run: check,
+      check_id: check?.id,
+      check_run_id: check?.id,
+      check_suite_id: check?.check_suite?.id,
+      pull_request_number: pr?.number,
+      head_sha: check?.head_sha ?? pr?.head?.sha,
+      head_ref: pr?.head?.ref,
+      base_ref: pr?.base?.ref,
+      name: check?.name,
+      status: check?.status,
+      conclusion: check?.conclusion,
+    }
+  }
+  if event_kind == "check_suite" {
+    let suite = raw?.check_suite ?? {}
+    let pr = __first(suite?.pull_requests)
+    return common
+      + {
+      check_suite: suite,
+      check_suite_id: suite?.id,
+      pull_request_number: pr?.number,
+      head_sha: suite?.head_sha,
+      head_ref: suite?.head_branch ?? pr?.head?.ref,
+      base_ref: pr?.base?.ref,
+      status: suite?.status,
+      conclusion: suite?.conclusion,
+    }
+  }
+  if event_kind == "workflow_run" {
+    let run = raw?.workflow_run ?? {}
+    let pr = __first(run?.pull_requests)
+    return common
+      + {
+      workflow_run: run,
+      run_id: run?.id,
+      run_number: run?.run_number,
+      workflow_id: run?.workflow_id,
+      check_suite_id: run?.check_suite_id,
+      pull_request_number: pr?.number,
+      head_sha: run?.head_sha ?? pr?.head?.sha,
+      head_ref: run?.head_branch ?? pr?.head?.ref,
+      base_ref: pr?.base?.ref,
+      name: run?.name,
+      status: run?.status,
+      conclusion: run?.conclusion,
+    }
+  }
+  if event_kind == "status" {
+    let branch = __first(raw?.branches)
+    return common
+      + {
+      commit_status: raw,
+      status_id: raw?.id,
+      head_sha: raw?.sha,
+      head_ref: branch?.name,
+      base_ref: branch?.name,
+      state: raw?.state,
+      context: raw?.context,
+      target_url: raw?.target_url,
+    }
+  }
+  if event_kind == "merge_group" {
+    let group = raw?.merge_group ?? {}
+    return common
+      + {
+      merge_group: group,
+      merge_group_id: group?.id,
+      head_sha: group?.head_sha,
+      head_ref: group?.head_ref,
+      base_sha: group?.base_sha,
+      base_ref: group?.base_ref,
+      pull_requests: group?.pull_requests ?? raw?.pull_requests ?? [],
+      pull_request_numbers: __pull_request_numbers(group?.pull_requests ?? raw?.pull_requests),
+    }
+  }
+  if event_kind == "push" {
+    return common
+      + {
+      ref: raw?.ref,
+      ref_name: __ref_name(raw?.ref),
+      before: raw?.before,
+      after: raw?.after,
+      head_sha: raw?.after,
+      head_ref: __ref_name(raw?.ref),
+      commits: raw?.commits ?? [],
+      distinct_size: raw?.distinct_size,
+      head_commit: raw?.head_commit,
+      pusher: raw?.pusher,
+      deleted: raw?.deleted ?? false,
+      forced: raw?.forced ?? false,
+      created: raw?.created ?? false,
+    }
+  }
+  if event_kind == "installation" {
+    return common
+      + {
+      installation: raw?.installation,
+      account: raw?.installation?.account ?? raw?.account,
+      installation_id: raw?.installation?.id,
+      installation_state: __installation_state(raw?.action),
+      suspended: __is_suspension_action(raw?.action),
+      revoked: __is_revocation_action(raw?.action),
+      repositories: raw?.repositories ?? [],
+    }
+  }
+  if event_kind == "installation_repositories" {
+    return common
+      + {
+      installation: raw?.installation,
+      account: raw?.installation?.account ?? raw?.account,
+      installation_id: raw?.installation?.id,
+      installation_state: __installation_state(raw?.action),
+      suspended: __is_suspension_action(raw?.action),
+      revoked: __is_revocation_action(raw?.action),
+      repository_selection: raw?.repository_selection,
+      repositories_added: raw?.repositories_added ?? [],
+      repositories_removed: raw?.repositories_removed ?? [],
+    }
+  }
+  if event_kind == "issues" {
+    return common + {issue: raw?.issue}
+  }
+  if event_kind == "issue_comment" {
+    return common + {issue: raw?.issue, comment: raw?.comment}
+  }
+  if event_kind == "pull_request_review" {
+    let pr = raw?.pull_request ?? {}
+    return common
+      + {
+      pull_request: pr,
+      review: raw?.review,
+      pull_request_number: pr?.number,
+      head_sha: pr?.head?.sha,
+      head_ref: pr?.head?.ref,
+      base_sha: pr?.base?.sha,
+      base_ref: pr?.base?.ref,
+    }
+  }
+  if event_kind == "deployment_status" {
+    return common + {deployment_status: raw?.deployment_status, deployment: raw?.deployment}
+  }
+  return common
+}
+
+fn __topic(event_kind, action) {
+  let prefix = "github." + to_string(event_kind)
+  if action == nil || trim(to_string(action)) == "" {
+    return prefix
+  }
+  return prefix + "." + to_string(action)
+}
+
+fn __first(values) {
+  let list = values ?? []
+  if len(list) == 0 {
+    return nil
+  }
+  return list[0]
+}
+
+fn __pull_request_numbers(pulls) {
+  var numbers = []
+  for pr in pulls ?? [] {
+    if pr?.number != nil {
+      numbers = numbers + [pr.number]
+    }
+  }
+  return numbers
+}
+
+fn __ref_name(ref) {
+  if ref == nil {
+    return nil
+  }
+  let text = to_string(ref)
+  if starts_with(text, "refs/heads/") {
+    return text[11:len(text)]
+  }
+  if starts_with(text, "refs/tags/") {
+    return text[10:len(text)]
+  }
+  return text
+}
+
+fn __installation_state(action) {
+  let value = to_string(action ?? "")
+  if __is_suspension_action(value) {
+    return "suspended"
+  }
+  if value == "unsuspend" || value == "unsuspended" {
+    return "active"
+  }
+  if __is_revocation_action(value) {
+    return "revoked"
+  }
+  return nil
+}
+
+fn __is_suspension_action(action) {
+  let value = to_string(action ?? "")
+  return value == "suspend" || value == "suspended"
+}
+
+fn __is_revocation_action(action) {
+  let value = to_string(action ?? "")
+  return value == "deleted" || value == "removed" || value == "revoked"
 }
 
 fn __repo(payload) {
@@ -967,7 +1242,12 @@ fn __repo(payload) {
   let owner = repo?.owner ?? {}
   let owner_name = owner?.login ?? owner?.name ?? ""
   let repo_name = repo?.name ?? ""
-  return {owner: owner_name, name: repo_name, full_name: repo?.full_name ?? owner_name + "/" + repo_name}
+  let fallback_full_name = if owner_name == "" || repo_name == "" {
+    ""
+  } else {
+    owner_name + "/" + repo_name
+  }
+  return {owner: owner_name, name: repo_name, full_name: repo?.full_name ?? fallback_full_name}
 }
 
 fn __occurred_at(event_kind, payload, raw) {
@@ -995,9 +1275,23 @@ fn __occurred_at(event_kind, payload, raw) {
     return payload?.workflow_run?.updated_at ?? payload?.workflow_run?.created_at
       ?? payload?.workflow_run?.run_started_at
   }
+  if event_kind == "check_suite" {
+    return payload?.check_suite?.updated_at ?? payload?.check_suite?.created_at
+  }
   if event_kind == "deployment_status" {
     return payload?.deployment_status?.created_at ?? payload?.deployment_status?.updated_at
       ?? payload?.deployment?.created_at
+  }
+  if event_kind == "status" {
+    return payload?.updated_at ?? payload?.created_at
+  }
+  if event_kind == "merge_group" {
+    return payload?.merge_group?.updated_at ?? payload?.merge_group?.created_at
+      ?? payload?.merge_group?.head_commit?.timestamp
+  }
+  if event_kind == "installation" || event_kind == "installation_repositories" {
+    return payload?.installation?.updated_at ?? payload?.installation?.created_at
+      ?? payload?.installation?.suspended_at
   }
   return payload?.check_run?.completed_at ?? payload?.check_run?.started_at
     ?? payload?.check_run?.created_at

--- a/tests/fixtures/webhooks/check_suite_requested.json
+++ b/tests/fixtures/webhooks/check_suite_requested.json
@@ -1,13 +1,11 @@
 {
-  "action": "completed",
-  "check_run": {
-    "id": 8001,
-    "name": "Harn CI",
-    "status": "completed",
-    "conclusion": "success",
-    "html_url": "https://github.com/octo-org/octo-repo/runs/8001",
+  "action": "requested",
+  "check_suite": {
+    "id": 8101,
+    "status": "queued",
+    "conclusion": null,
+    "head_branch": "feature/connector-fixture",
     "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
-    "check_suite": {"id": 8101},
     "pull_requests": [
       {
         "number": 42,
@@ -15,8 +13,8 @@
         "base": {"ref": "main", "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
       }
     ],
-    "started_at": "2026-04-20T16:00:00Z",
-    "completed_at": "2026-04-20T16:03:00Z"
+    "created_at": "2026-04-20T15:59:00Z",
+    "updated_at": "2026-04-20T15:59:00Z"
   },
   "repository": {
     "name": "octo-repo",

--- a/tests/fixtures/webhooks/installation_deleted.json
+++ b/tests/fixtures/webhooks/installation_deleted.json
@@ -1,0 +1,12 @@
+{
+  "action": "deleted",
+  "installation": {
+    "id": 3001,
+    "account": {"id": 2001, "login": "octo-org", "type": "Organization"},
+    "repository_selection": "selected"
+  },
+  "repositories": [
+    {"id": 4001, "name": "octo-repo", "full_name": "octo-org/octo-repo", "private": false}
+  ],
+  "sender": {"id": 1003, "login": "admin", "type": "User"}
+}

--- a/tests/fixtures/webhooks/installation_repositories_removed.json
+++ b/tests/fixtures/webhooks/installation_repositories_removed.json
@@ -1,0 +1,14 @@
+{
+  "action": "removed",
+  "installation": {
+    "id": 3001,
+    "account": {"id": 2001, "login": "octo-org", "type": "Organization"},
+    "repository_selection": "selected"
+  },
+  "repository_selection": "selected",
+  "repositories_added": [],
+  "repositories_removed": [
+    {"id": 4001, "name": "octo-repo", "full_name": "octo-org/octo-repo", "private": false}
+  ],
+  "sender": {"id": 1003, "login": "admin", "type": "User"}
+}

--- a/tests/fixtures/webhooks/installation_suspend.json
+++ b/tests/fixtures/webhooks/installation_suspend.json
@@ -1,0 +1,14 @@
+{
+  "action": "suspend",
+  "installation": {
+    "id": 3001,
+    "account": {"id": 2001, "login": "octo-org", "type": "Organization"},
+    "repository_selection": "selected",
+    "suspended_at": "2026-04-20T18:00:00Z",
+    "suspended_by": {"id": 1003, "login": "admin", "type": "User"}
+  },
+  "repositories": [
+    {"id": 4001, "name": "octo-repo", "full_name": "octo-org/octo-repo", "private": false}
+  ],
+  "sender": {"id": 1003, "login": "admin", "type": "User"}
+}

--- a/tests/fixtures/webhooks/merge_group_checks_requested.json
+++ b/tests/fixtures/webhooks/merge_group_checks_requested.json
@@ -1,22 +1,19 @@
 {
-  "action": "completed",
-  "check_run": {
-    "id": 8001,
-    "name": "Harn CI",
-    "status": "completed",
-    "conclusion": "success",
-    "html_url": "https://github.com/octo-org/octo-repo/runs/8001",
-    "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
-    "check_suite": {"id": 8101},
+  "action": "checks_requested",
+  "merge_group": {
+    "id": 9201,
+    "head_ref": "gh-readonly-queue/main/pr-42-cccccccccccc",
+    "head_sha": "dddddddddddddddddddddddddddddddddddddddd",
+    "base_ref": "main",
+    "base_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "head_commit": {"timestamp": "2026-04-20T16:06:00Z"},
     "pull_requests": [
       {
         "number": 42,
         "head": {"ref": "feature/connector-fixture", "sha": "cccccccccccccccccccccccccccccccccccccccc"},
         "base": {"ref": "main", "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
       }
-    ],
-    "started_at": "2026-04-20T16:00:00Z",
-    "completed_at": "2026-04-20T16:03:00Z"
+    ]
   },
   "repository": {
     "name": "octo-repo",

--- a/tests/fixtures/webhooks/pull_request_opened.json
+++ b/tests/fixtures/webhooks/pull_request_opened.json
@@ -8,6 +8,16 @@
     "html_url": "https://github.com/octo-org/octo-repo/pull/42",
     "created_at": "2026-04-20T12:00:00Z",
     "updated_at": "2026-04-20T12:05:00Z",
+    "head": {
+      "ref": "feature/connector-fixture",
+      "sha": "cccccccccccccccccccccccccccccccccccccccc"
+    },
+    "base": {
+      "ref": "main",
+      "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "draft": false,
+    "merged": false,
     "user": {"id": 1001, "login": "octocat", "type": "User"}
   },
   "repository": {

--- a/tests/fixtures/webhooks/status_success.json
+++ b/tests/fixtures/webhooks/status_success.json
@@ -1,0 +1,18 @@
+{
+  "id": 9101,
+  "sha": "cccccccccccccccccccccccccccccccccccccccc",
+  "state": "success",
+  "context": "legacy/status",
+  "target_url": "https://ci.example.test/octo-repo/9101",
+  "description": "Legacy CI passed",
+  "branches": [{"name": "main"}],
+  "created_at": "2026-04-20T16:05:00Z",
+  "updated_at": "2026-04-20T16:05:00Z",
+  "repository": {
+    "name": "octo-repo",
+    "full_name": "octo-org/octo-repo",
+    "owner": {"id": 2001, "login": "octo-org", "type": "Organization"}
+  },
+  "sender": {"id": 1001, "login": "octocat", "type": "User"},
+  "installation": {"id": 3001}
+}

--- a/tests/fixtures/webhooks/workflow_run_completed.json
+++ b/tests/fixtures/webhooks/workflow_run_completed.json
@@ -6,6 +6,18 @@
     "status": "completed",
     "conclusion": "success",
     "html_url": "https://github.com/octo-org/octo-repo/actions/runs/6001",
+    "run_number": 12,
+    "workflow_id": 6101,
+    "check_suite_id": 8101,
+    "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "head_branch": "feature/connector-fixture",
+    "pull_requests": [
+      {
+        "number": 42,
+        "head": {"ref": "feature/connector-fixture", "sha": "cccccccccccccccccccccccccccccccccccccccc"},
+        "base": {"ref": "main", "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+      }
+    ],
     "run_started_at": "2026-04-20T16:00:00Z",
     "created_at": "2026-04-20T16:00:00Z",
     "updated_at": "2026-04-20T16:04:00Z"

--- a/tests/normalize_events.harn
+++ b/tests/normalize_events.harn
@@ -12,15 +12,39 @@ pipeline default() {
     ["workflow_run_completed", "workflow_run", "workflow_run.completed"],
     ["deployment_status_created", "deployment_status", "deployment_status.created"],
     ["check_run_completed", "check_run", "check_run.completed"],
+    ["check_suite_requested", "check_suite", "check_suite.requested"],
+    ["status_success", "status", "status"],
+    ["merge_group_checks_requested", "merge_group", "merge_group.checks_requested"],
+    ["installation_suspend", "installation", "installation.suspend"],
+    ["installation_deleted", "installation", "installation.deleted"],
+    [
+      "installation_repositories_removed",
+      "installation_repositories",
+      "installation_repositories.removed",
+    ],
   ]
   for [name, event, event_type] in cases {
     let normalized = github_normalize(fixture_raw(name, secret, event))
     assert_eq(normalized.type, "event", name + " envelope type")
     assert_eq(normalized.event.kind, event, name + " event kind")
+    assert_eq(normalized.event.payload.provider, "github", name + " provider")
+    assert_eq(normalized.event.payload.event, event, name + " payload event")
+    assert_eq(normalized.event.payload.delivery_id, "delivery-1", name + " delivery id")
+    assert_eq(
+      normalized.event.payload.raw.sender.login,
+      normalized.event.payload.sender.login,
+      name + " raw preserved",
+    )
     if contains(event_type, ".") {
       assert_eq(event + "." + normalized.event.payload.action, event_type, name + " payload event type")
+      assert_eq(normalized.event.topic, "github." + event_type, name + " topic")
+    } else {
+      assert_eq(normalized.event.topic, "github." + event_type, name + " topic")
     }
-    assert_eq(normalized.event.payload.repository.full_name, "octo-org/octo-repo", name + " repo")
+    if normalized.event.payload.repository != nil {
+      assert_eq(normalized.event.payload.repository.full_name, "octo-org/octo-repo", name + " repo")
+      assert_eq(normalized.event.payload.repo.full_name, "octo-org/octo-repo", name + " normalized repo")
+    }
   }
   let unsupported = github_normalize(fixture_raw("issues_opened", secret, "member"))
   assert_eq(unsupported.type, "reject", "unsupported events reject in v0")

--- a/tests/normalize_smoke.harn
+++ b/tests/normalize_smoke.harn
@@ -16,11 +16,21 @@ pipeline default() {
   assert_eq(pr.event.signature_status.state, "verified", "pr signed")
   assert_eq(pr.event.payload.action, "opened", "pull request action")
   assert_eq(pr.event.payload.pull_request.number, 42, "pull request number")
+  assert_eq(pr.event.payload.pull_request_number, 42, "normalized pull request number")
+  assert_eq(
+    pr.event.payload.head_sha,
+    "cccccccccccccccccccccccccccccccccccccccc",
+    "normalized pr head sha",
+  )
+  assert_eq(pr.event.payload.base_ref, "main", "normalized pr base ref")
+  assert_eq(pr.event.payload.topic, "github.pull_request.opened", "normalized pr topic")
   assert_eq(pr.event.payload.sender.login, "octocat", "pull request actor")
   assert(pr.event.dedupe_key != "" && pr.event.dedupe_key != nil, "pr dedupe key populated")
   let push = github_normalize(fixture_raw("push", secret, "push"))
   assert_eq(push.event.kind, "push", "push event kind")
   assert_eq(push.event.payload.after, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "push after")
+  assert_eq(push.event.payload.head_sha, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "push head sha")
+  assert_eq(push.event.payload.head_ref, "main", "push ref name")
   let issues = github_normalize(fixture_raw("issues_opened", secret, "issues"))
   assert_eq(issues.event.kind, "issues", "issues event kind")
   assert_eq(issues.event.payload.issue.number, 7, "issue number")
@@ -33,12 +43,50 @@ pipeline default() {
   let workflow = github_normalize(fixture_raw("workflow_run_completed", secret, "workflow_run"))
   assert_eq(workflow.event.kind, "workflow_run", "workflow run event kind")
   assert_eq(workflow.event.payload.workflow_run.conclusion, "success", "workflow conclusion")
+  assert_eq(workflow.event.payload.run_id, 6001, "workflow run id")
+  assert_eq(workflow.event.payload.check_suite_id, 8101, "workflow suite id")
+  assert_eq(workflow.event.payload.pull_request_number, 42, "workflow pr number")
   let deployment = github_normalize(fixture_raw("deployment_status_created", secret, "deployment_status"))
   assert_eq(deployment.event.kind, "deployment_status", "deployment status event kind")
   assert_eq(deployment.event.payload.deployment.environment, "staging", "deployment environment")
   let check = github_normalize(fixture_raw("check_run_completed", secret, "check_run"))
   assert_eq(check.event.kind, "check_run", "check run event kind")
   assert_eq(check.event.payload.check_run.conclusion, "success", "check conclusion")
+  assert_eq(check.event.payload.check_id, 8001, "check run id")
+  assert_eq(check.event.payload.check_suite_id, 8101, "check suite id")
+  assert_eq(check.event.payload.pull_request_number, 42, "check pr number")
+  let suite = github_normalize(fixture_raw("check_suite_requested", secret, "check_suite"))
+  assert_eq(suite.event.kind, "check_suite", "check suite event kind")
+  assert_eq(suite.event.payload.check_suite_id, 8101, "check suite normalized id")
+  assert_eq(suite.event.payload.head_ref, "feature/connector-fixture", "check suite head ref")
+  let status = github_normalize(fixture_raw("status_success", secret, "status"))
+  assert_eq(status.event.kind, "status", "status event kind")
+  assert_eq(status.event.payload.status_id, 9101, "status normalized id")
+  assert_eq(status.event.payload.head_sha, "cccccccccccccccccccccccccccccccccccccccc", "status sha")
+  let group = github_normalize(fixture_raw("merge_group_checks_requested", secret, "merge_group"))
+  assert_eq(group.event.kind, "merge_group", "merge group event kind")
+  assert_eq(group.event.payload.merge_group_id, 9201, "merge group id")
+  assert_eq(group.event.payload.pull_request_numbers[0], 42, "merge group pull number")
+  let suspended = github_normalize(fixture_raw("installation_suspend", secret, "installation"))
+  assert_eq(suspended.event.kind, "installation", "installation event kind")
+  assert_eq(suspended.event.payload.installation_state, "suspended", "installation suspension state")
+  assert(suspended.event.payload.suspended, "installation suspension flag")
+  let deleted = github_normalize(fixture_raw("installation_deleted", secret, "installation"))
+  assert_eq(deleted.event.payload.installation_state, "revoked", "installation revocation state")
+  assert(deleted.event.payload.revoked, "installation revocation flag")
+  let repo_removed = github_normalize(
+    fixture_raw("installation_repositories_removed", secret, "installation_repositories"),
+  )
+  assert_eq(
+    repo_removed.event.kind,
+    "installation_repositories",
+    "installation repositories event kind",
+  )
+  assert_eq(
+    repo_removed.event.payload.repositories_removed[0].full_name,
+    "octo-org/octo-repo",
+    "removed repo",
+  )
   let body = fixture_body("issues_opened")
   let tampered = github_normalize(
     {signing_secret: secret, body_text: body + " ", headers: github_headers(secret, body, "issues")},


### PR DESCRIPTION
## Summary

Closes #18.

- Add normalized GitHub webhook payloads with stable `github.<event>[.<action>]` topics and promoted fields for PRs, checks, workflow runs, legacy statuses, merge groups, pushes, and installation events.
- Add support for `check_suite`, `status`, `merge_group`, `installation`, and `installation_repositories` inbound events.
- Add deterministic webhook fixtures and contract coverage for the new event families, including installation suspension/revocation cases.
- Document the stable subscription topics and promoted fields for Merge Captain/release workflow consumers.

## Self-review

I re-read the diff after the full check pass for schema drift, dedupe behavior, raw payload handling, duplicated normalizer logic, and host contract behavior. One nuance: Harn core still serializes newly introduced GitHub kinds as generic provider payloads in connector contract checks, so those fixtures assert the stable common envelope while the connector-level Harn tests assert the promoted event-specific fields directly.

## Validation

```sh
harn check src/lib.harn
harn lint src/lib.harn
harn fmt --check src tests
harn connector check . --provider github
for test in tests/*.harn; do harn run "$test" || exit 1; done
```

Also ran `git diff --check`.