### PR TITLE
Release harn-github-connector v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
-## Unreleased
+## 0.2.0 - 2026-05-02
+
+- Add typed normalized webhook payloads and stable `github.<event>[.<action>]`
+  topics for Merge Captain and release workflow consumers.
+- Add inbound support for `check_suite`, `status`, `merge_group`,
+  `installation`, and `installation_repositories` webhooks.
+- Promote PR/check/workflow/status/merge-group identifiers such as
+  `pull_request_number`, `head_sha`, `base_ref`, `run_id`, `check_id`,
+  `check_suite_id`, and `merge_group_id`.
+- Promote installation suspension and revocation fields so hosted consumers can
+  pause affected captains cleanly.
+- Add deterministic replay fixtures and connector contract coverage for the new
+  event families.
+- Document stable GitHub webhook topics and promoted payload fields.
 
 - Add typed outbound methods for PR list/view/checks/merge/comment, Actions
   logs, merge queue entries/enqueue, issue create/comment, and branch

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pure-Harn GitHub App connector for the Harn orchestrator. Verifies inbound
 webhook signatures, normalizes GitHub event payloads to the canonical
 `TriggerEvent` shape, and dispatches outbound REST/GraphQL calls.
 
-> **Status: v0.1.0** — production-ready first-party connector package,
+> **Status: v0.2.0** — production-ready first-party connector package,
 > verified with the published `harn-cli` 0.7.48 release.
 
 This is an **inbound + outbound** connector implementing the Harn Connector
@@ -23,7 +23,7 @@ harn --version
 Add the released connector package:
 
 ```sh
-harn add github.com/burin-labs/harn-github-connector@v0.1.0
+harn add github.com/burin-labs/harn-github-connector@v0.2.0
 ```
 
 For local multi-repo development, a path dependency is still useful:

--- a/harn.toml
+++ b/harn.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harn-github-connector"
-version = "0.1.0"
+version = "0.2.0"
 description = "Pure-Harn GitHub App connector: webhooks, installation token rotation, REST/GraphQL dispatch."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn-github-connector"


### PR DESCRIPTION
## Summary

- Bump `harn-github-connector` to `0.2.0`.
- Add the `0.2.0` changelog entry for the merged webhook normalization and existing unreleased outbound SDK additions.
- Update README install/status snippets to `v0.2.0`.

## Validation

```sh
scripts/check-release.sh v0.2.0
git diff --check
```

Release validation included `harn check`, `harn lint`, `harn fmt --check`, `harn connector check`, all test files, and a clean package consumer install/import smoke.