### PR TITLE
[codex] Point connector guidance at canonical Harn guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Check connector guidance is canonical
+        shell: bash
+        run: |
+          set -euo pipefail
+          guidance_files=()
+          for file in CLAUDE.md AGENTS.md; do
+            if [[ -f "${file}" ]]; then
+              guidance_files+=("${file}")
+            fi
+          done
+          if [[ "${#guidance_files[@]}" -eq 0 ]]; then
+            echo "Add CLAUDE.md or AGENTS.md with a pointer to the canonical connector authoring guide." >&2
+            exit 1
+          fi
+          copied_guidance='(^## (Quick repo conventions|How to test|Reference Rust impl|Upstream conventions|Harn module connectors|Connector package gate|Rust connectors|Testing|Development)$|File extension:|Entry point:|Tests live under|Run targeted checks|Run checks|cargo install harn-cli|harn --version|harn install|harn (check|lint|fmt|connector (check|test))|for test in tests/\*\.harn)'
+          for file in "${guidance_files[@]}"; do
+            if ! grep -Eq 'docs/src/connectors/authoring\.md|docs\.harnlang\.com/connectors/authoring\.html' "${file}"; then
+              echo "${file} must link to docs/src/connectors/authoring.md instead of restating it." >&2
+              exit 1
+            fi
+            if grep -Eiq "${copied_guidance}" "${file}"; then
+              echo "${file} is re-implementing canonical Harn authoring guidance; keep only provider-specific notes." >&2
+              exit 1
+            fi
+          done
+          if [[ -f CLAUDE.md ]] && ! grep -Eq '^## Provider Notes$' CLAUDE.md; then
+            echo "CLAUDE.md must keep local content under a Provider Notes section." >&2
+            exit 1
+          fi
+
       - name: Read Harn version
         id: harn-version
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,56 +1,8 @@
-# AGENTS.md — harn-github-connector
+# AGENTS.md
 
-This repository ships the first-party pure-Harn GitHub connector package.
-Treat `harn.toml`, `src/lib.harn`, and the deterministic fixtures in `tests/`
-as the current source of truth for connector behavior.
+Use `CLAUDE.md` in this repository for provider-specific notes. Shared connector authoring rules
+live in the canonical Harn guide:
 
-## Quick repo conventions
+- https://github.com/burin-labs/harn/blob/main/docs/src/connectors/authoring.md
 
-- File extension: `.harn`. Use `snake_case` for filenames.
-- Repo directories use `kebab-case`.
-- Entry point: `src/lib.harn`.
-- Tests live under `tests/`. Recorded webhook fixtures live under
-  `tests/fixtures/webhooks/`.
-
-## How to test
-
-Install the pinned Harn CLI from crates.io:
-
-```sh
-cargo install harn-cli --version "$(cat .harn-version)" --locked
-harn --version
-```
-
-Run checks from the repo root:
-
-```sh
-harn check src/lib.harn
-harn lint src/lib.harn
-harn fmt --check src tests
-harn connector check . --provider github
-for test in tests/*.harn; do
-  harn run "$test" || exit 1
-done
-```
-
-## Reference Rust impl
-
-The existing 1243-LOC Rust connector at
-`/Users/ksinder/projects/harn/crates/harn-vm/src/connectors/github/mod.rs`
-is the **behavior spec**. Port semantics from there.
-
-## Sibling future repo
-
-A typed `github-sdk-harn` (REST + GraphQL) is plausible future work,
-modeled after `notion-sdk-harn`. It is out of scope for this connector package.
-
-## Upstream conventions
-
-For general Harn coding conventions and project layout, defer to
-[`/Users/ksinder/projects/harn/AGENTS.md`](/Users/ksinder/projects/harn/AGENTS.md).
-
-## Don't
-
-- Don't bake an OpenAPI-codegen GitHub SDK into this repo. If you need a
-  typed surface, propose `github-sdk-harn` as a separate repo first.
-- Don't hand-edit `LICENSE-*` or `.gitignore`.
+Keep this file as a pointer. Add shared connector guidance to the Harn guide first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,52 +1,19 @@
-# CLAUDE.md — harn-github-connector
+# CLAUDE.md - harn-github-connector
 
-## Quick repo conventions
+Pure-Harn GitHub App connector package for inbound webhooks and outbound REST/GraphQL calls.
 
-- File extension: `.harn`. Use `snake_case` for filenames.
-- Repo directories use `kebab-case`.
-- Entry point: `src/lib.harn`.
-- Tests live under `tests/`. Recorded webhook fixtures live under
-  `tests/fixtures/webhooks/`.
+Shared Harn connector authoring rules live in the canonical guide:
 
-## How to test
+- https://github.com/burin-labs/harn/blob/main/docs/src/connectors/authoring.md
 
-Install the pinned Harn CLI from crates.io:
+Keep this file limited to provider-specific notes and local hazards. Add shared connector guidance
+to the Harn guide first.
 
-```sh
-cargo install harn-cli --version "$(cat .harn-version)" --locked
-harn --version
-```
+## Provider Notes
 
-Run checks from the repo root:
-
-```sh
-harn check src/lib.harn
-harn lint src/lib.harn
-harn fmt --check src/lib.harn tests/*.harn
-harn connector check .
-for test in tests/*.harn; do
-  harn run "$test" || exit 1
-done
-```
-
-## Reference Rust impl
-
-The existing 1243-LOC Rust connector at
-`/Users/ksinder/projects/harn/crates/harn-vm/src/connectors/github/mod.rs`
-is the **behavior spec**. Port semantics from there.
-
-## Sibling future repo
-
-A typed `github-sdk-harn` (REST + GraphQL) is plausible future work,
-modeled after `notion-sdk-harn`. Out of scope for this repo's v0.
-
-## Upstream conventions
-
-For general Harn coding conventions and project layout, defer to
-[`/Users/ksinder/projects/harn/CLAUDE.md`](/Users/ksinder/projects/harn/CLAUDE.md).
-
-## Don't
-
-- Don't bake an OpenAPI-codegen GitHub SDK into this repo. If you need a
-  typed surface, propose `github-sdk-harn` as a separate repo first.
-- Don't hand-edit `LICENSE-*` or `.gitignore`.
+- Webhook verification uses `X-Hub-Signature-256` over the raw request body with the configured
+  GitHub App webhook secret.
+- Outbound installation-token flow depends on GitHub App credentials: app id, private key, and
+  installation id. Keep token refresh behavior aligned with GitHub App expiry semantics.
+- A typed `github-sdk-harn` would be a separate package; this connector should not grow generated
+  REST endpoint definitions.


### PR DESCRIPTION
## Summary
- replace repo-local agent guidance with a canonical Harn connector authoring pointer
- keep provider-specific hazards in `CLAUDE.md` and keep `AGENTS.md` as a short pointer
- add a CI guard that fails when local guidance copies shared Harn authoring or test instructions

## Verification
- local guidance guard passed
- `actionlint .github/workflows/ci.yml`
- `npx markdownlint-cli2 CLAUDE.md AGENTS.md`
- `git diff --check`

Refs burin-labs/harn#937.
