### PR TITLE
Release harn-github-connector v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.3.0 - 2026-05-06
+
+- Add repository automation helpers for typed PR, Actions, merge queue, issue,
+  branch-protection, and repository-content workflows.
+- Add orchestration helpers for dispatching and waiting on workflows, waiting
+  for PR checks, enabling auto-merge, finding open PRs, and closing PRs.
+- Add deterministic conformance coverage for the new repository automation and
+  orchestration helper surfaces.
+- Add connector CI and release workflows, plus a scheduled Harn runtime bump
+  workflow.
+- Bump the verified Harn runtime to `harn-cli` 0.7.60.
+
 ## 0.2.0 - 2026-05-02
 
 - Add typed normalized webhook payloads and stable `github.<event>[.<action>]`

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Pure-Harn GitHub App connector for the Harn orchestrator. Verifies inbound
 webhook signatures, normalizes GitHub event payloads to the canonical
 `TriggerEvent` shape, and dispatches outbound REST/GraphQL calls.
 
-> **Status: v0.2.0** — production-ready first-party connector package,
-> verified with the published `harn-cli` 0.7.48 release.
+> **Status: v0.3.0** — production-ready first-party connector package,
+> verified with the published `harn-cli` 0.7.60 release.
 
 This is an **inbound + outbound** connector implementing the Harn Connector
 Contract v1 documented in the
@@ -23,7 +23,7 @@ harn --version
 Add the released connector package:
 
 ```sh
-harn add github.com/burin-labs/harn-github-connector@v0.2.0
+harn add github.com/burin-labs/harn-github-connector@v0.3.0
 ```
 
 For local multi-repo development, a path dependency is still useful:

--- a/harn.toml
+++ b/harn.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harn-github-connector"
-version = "0.2.0"
+version = "0.3.0"
 description = "Pure-Harn GitHub App connector: webhooks, installation token rotation, REST/GraphQL dispatch."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn-github-connector"


### PR DESCRIPTION
## Summary
- bump the connector package metadata to v0.3.0
- document the new repository automation and orchestration helper APIs
- update the verified Harn runtime note to 0.7.60

## Verification
- `scripts/check-release.sh v0.3.0`
- `harn fmt --check src tests`
