### PR TITLE
Add GitHub release helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add latest-release and release-asset helpers for release automation.
+- Add `api_call` as a raw REST compatibility escape hatch.
+
 ## 0.3.0 - 2026-05-06
 
 - Add repository automation helpers for typed PR, Actions, merge queue, issue,

--- a/README.md
+++ b/README.md
@@ -118,11 +118,14 @@ Outbound methods:
 | `github.actions.runs` | Typed workflow-run list helper for a repo slug |
 | `github.actions.run` | Typed workflow-run fetch helper for a repo slug |
 | `github.actions.logs` | Fetch Actions logs by `run_id` or by `check_id` when the check links to an Actions run |
+| `github.release.latest` | Stable latest-release envelope with tag and asset names |
+| `github.release.assets` | Stable release-assets envelope, defaulting to the latest release when no release id is supplied |
 | `github.merge_queue.entries` | Typed merge queue entries for a base branch |
 | `github.merge_queue.enqueue` | Enqueue a PR on the merge queue |
 | `github.issue.create` | Typed issue create helper |
 | `github.issue.comment` | Typed issue comment helper |
 | `github.branch.protection` | Typed branch protection summary |
+| `api_call` | Raw GitHub REST escape hatch for endpoints without typed helpers |
 | `issues.create_comment` | `POST /repos/{owner}/{repo}/issues/{issue_number}/comments` |
 | `issues.create` | `POST /repos/{owner}/{repo}/issues` |
 | `issues.create_with_template` | Convenience helper over `issues.create` |
@@ -139,6 +142,8 @@ Outbound methods:
 | `pulls.list_reviews` | `GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews` |
 | `repos.get_content` | `GET /repos/{owner}/{repo}/contents/{path}` |
 | `repos.get_text` | Convenience wrapper over `repos.get_content` that decodes base64 file content |
+| `repos.get_latest_release` | `GET /repos/{owner}/{repo}/releases/latest` |
+| `repos.list_release_assets` | `GET /repos/{owner}/{repo}/releases/{release_id}/assets` |
 | `repos.get_branch_protection` | `GET /repos/{owner}/{repo}/branches/{branch}/protection` |
 | `git.delete_ref` | `DELETE /repos/{owner}/{repo}/git/refs/{ref}` |
 | `actions.workflow_dispatch` | `POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches` |
@@ -162,6 +167,8 @@ shape without inspecting raw GitHub responses.
 | `github_wait_for_pr_checks(owner, repo, pull_number_or_ref, options)` | Wait for visible CI checks on a PR or commit to leave the queued/pending state. Optionally summarizes failing-check Actions logs. |
 | `github_find_open_pr(owner, repo, options)` | Find the first open PR matching simple `head_ref`/`base_ref`/`title`/`labels` filters. |
 | `github_close_pr(owner, repo, pull_number, comment, options)` | Close a PR, optionally posting a final comment first. |
+| `github_latest_release(owner, repo, options)` | Fetch latest release metadata and asset names as a stable envelope. |
+| `github_release_assets(owner, repo, release_id, options)` | List release assets as a stable envelope; when `release_id` is omitted it uses the latest release. |
 
 Common option fields:
 
@@ -215,6 +222,16 @@ github_find_open_pr →
 
 github_close_pr →
 { ok, pull_number, state, comment_posted, pull_request, error }
+
+github_latest_release →
+{
+  ok, repo, release_id, tag_name, name,
+  draft, prerelease, url, html_url, published_at,
+  assets, asset_names, raw, error,
+}
+
+github_release_assets →
+{ ok, repo, release_id, assets, asset_names, raw, error }
 ```
 
 These helpers are orchestration-level building blocks for harness authors.
@@ -236,6 +253,7 @@ use `call(method, args)` only for direct method dispatch.
 | Enable auto-merge | `pulls_enable_auto_merge(owner, repo, number, options)` or `call("github.pr.enable_auto_merge", {repo, number})` | Uses GitHub GraphQL auto-merge, normalizes `merge`/`squash`/`rebase`, and passes the expected head OID when available. Merge-queue repositories ignore the requested merge method as GitHub does. |
 | Dispatch workflows | `actions_workflow_dispatch(owner, repo, workflow_id, ref, inputs, options)` | Requests `return_run_details` by default so callers can poll the exact run when GitHub returns it. |
 | List workflow runs | `actions_workflow_runs(owner, repo, options)` or `call("actions.workflow_runs.list", args)` | Supports repository-wide or workflow-scoped listing with common run filters such as `event`, `branch`, `status`, `head_sha`, and pagination. |
+| Inspect latest release assets | `github_latest_release(owner, repo, options)` | Returns `tag_name`, `assets`, and `asset_names` without open-coding the releases endpoint. |
 | Fetch Actions logs | `call("github.actions.logs", {repo, run_id})` | `check_id` is also accepted when GitHub exposes an Actions run URL on the check run. |
 | Use merge queue | `call("github.merge_queue.entries", {repo, branch})` and `call("github.merge_queue.enqueue", {repo, branch, pr_number, method})` | Matches the mock playground merge queue surface used by managed captain workflows. |
 | List open PRs with merge state and CI rollup | `pulls_list_with_checks(owner, repo, state, limit, options)` or `call("pulls.list_with_checks", args)` | Uses GraphQL because `mergeStateStatus` and `statusCheckRollup` are GraphQL PR fields surfaced by `gh pr --json`; the REST list endpoint does not return the same check rollup shape. Returns `number`, `title`, `headRefName`, `baseRefName`, `isDraft`, `mergeStateStatus`, `statusCheckRollup`, and `url`. |
@@ -247,6 +265,7 @@ use `call(method, args)` only for direct method dispatch.
 | Add issue or PR labels | `call("issues.add_labels", args)` | Uses the issue-labels endpoint; GitHub models PRs as issues for labels. |
 | Inspect branch protection | `call("repos.get_branch_protection", args)` | Used by `pulls.merge_safe` before admin merges. |
 | Read repository file text | `repos_get_text(owner, repo, path, ref, options)` or `call("repos.get_text", args)` | Decodes GitHub contents API base64 file payloads and rejects directory listings. |
+| Use raw REST endpoints | `api_call(path, method, body, options)` or `call("api_call", args)` | Escape hatch for endpoints that do not yet justify a typed helper. |
 | List changed files | `call("pulls.list_files", args)` | Used by review/conflict workflows. |
 | List reviews | `call("pulls.list_reviews", args)` | Used by review workflows. |
 
@@ -299,6 +318,10 @@ Required GitHub App permissions depend on the outbound method:
   enforces repository auto-merge and merge-queue settings.
 - `pulls.create_review_comment`: Pull requests write.
 - `repos.get_content`, `repos.get_text`: Contents read.
+- `repos.get_latest_release`, `repos.list_release_assets`,
+  `github.release.latest`, `github.release.assets`: Contents read.
+- `api_call`: the installed app must have the permissions required by the
+  specific endpoint.
 - `repos.get_branch_protection`: Administration read.
 - `git.delete_ref`: Contents write.
 - `actions.workflow_dispatch`: Actions write.

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -17,11 +17,14 @@ let GITHUB_OUTBOUND_METHODS = [
   "github.actions.runs",
   "github.actions.run",
   "github.actions.logs",
+  "github.release.latest",
+  "github.release.assets",
   "github.merge_queue.entries",
   "github.merge_queue.enqueue",
   "github.issue.create",
   "github.issue.comment",
   "github.branch.protection",
+  "api_call",
   "issues.create_comment",
   "issues.create",
   "issues.create_with_template",
@@ -38,6 +41,8 @@ let GITHUB_OUTBOUND_METHODS = [
   "pulls.list_reviews",
   "repos.get_content",
   "repos.get_text",
+  "repos.get_latest_release",
+  "repos.list_release_assets",
   "repos.get_branch_protection",
   "git.delete_ref",
   "actions.workflow_dispatch",
@@ -236,6 +241,12 @@ pub fn call(method, args = {}) {
   if method == "github.actions.logs" {
     return __github_actions_logs(args, cfg)
   }
+  if method == "github.release.latest" {
+    return __github_release_latest(args, cfg)
+  }
+  if method == "github.release.assets" {
+    return __github_release_assets(args, cfg)
+  }
   if method == "github.merge_queue.entries" {
     return __github_merge_queue_entries(args, cfg)
   }
@@ -250,6 +261,9 @@ pub fn call(method, args = {}) {
   }
   if method == "github.branch.protection" {
     return __github_branch_protection(args, cfg)
+  }
+  if method == "api_call" {
+    return __api_call(args, cfg)
   }
   if method == "issues.create_comment" {
     return __github_json(
@@ -409,6 +423,12 @@ pub fn call(method, args = {}) {
   if method == "repos.get_text" {
     return __repos_get_text(args, cfg)
   }
+  if method == "repos.get_latest_release" {
+    return __repos_get_latest_release(args, cfg)
+  }
+  if method == "repos.list_release_assets" {
+    return __repos_list_release_assets(args, cfg)
+  }
   if method == "repos.get_branch_protection" {
     return __github_json(
       "GET",
@@ -510,6 +530,12 @@ pub fn actions_workflow_runs(owner, repo, options = nil) {
   return call("actions.workflow_runs.list", opts + {owner: owner, repo: repo})
 }
 
+/** Dispatch one raw GitHub REST call. Prefer typed helpers when one exists. */
+pub fn api_call(path, method = "GET", body = nil, options = nil) {
+  let opts = options ?? {}
+  return call("api_call", opts + {path: path, method: method, body: body})
+}
+
 /** Read a repository file as decoded UTF-8 text at an optional ref. */
 pub fn repos_get_text(owner, repo, path, ref = nil, options = nil) {
   let opts = options ?? {}
@@ -518,6 +544,32 @@ pub fn repos_get_text(owner, repo, path, ref = nil, options = nil) {
     args["ref"] = ref
   }
   return call("repos.get_text", args)
+}
+
+/** Fetch the latest published release for a repository. */
+pub fn repos_get_latest_release(owner, repo, options = nil) {
+  let opts = options ?? {}
+  return call("repos.get_latest_release", opts + {owner: owner, repo: repo})
+}
+
+/** List assets for a release id. */
+pub fn repos_list_release_assets(owner, repo, release_id, options = nil) {
+  let opts = options ?? {}
+  return call("repos.list_release_assets", opts + {owner: owner, repo: repo, release_id: release_id})
+}
+
+/** Fetch latest release metadata as a stable automation envelope. */
+pub fn github_latest_release(owner, repo, options = nil) {
+  let opts = options ?? {}
+  return call("github.release.latest", opts + {owner: owner, repo: repo})
+}
+
+/**
+ * List release assets as a stable automation envelope. Defaults to latest release when no id is supplied.
+ */
+pub fn github_release_assets(owner, repo, release_id = nil, options = nil) {
+  let opts = options ?? {}
+  return call("github.release.assets", opts + {owner: owner, repo: repo, release_id: release_id})
 }
 
 /** Create an issue from a small title/body template and variables. */
@@ -1471,6 +1523,40 @@ fn __github_actions_logs(args, cfg) {
   }
 }
 
+fn __github_release_latest(args, cfg) {
+  let repo = __repo_parts(args)
+  if is_err(repo) {
+    return __release_error_envelope(nil, unwrap_err(repo))
+  }
+  let r = unwrap(repo)
+  let release = __repos_get_latest_release(args + {owner: r.owner, repo: r.name}, cfg)
+  if is_err(release) {
+    return __release_error_envelope(r.full_name, unwrap_err(release))
+  }
+  return __release_envelope(r.full_name, unwrap(release))
+}
+
+fn __github_release_assets(args, cfg) {
+  let repo = __repo_parts(args)
+  if is_err(repo) {
+    return __release_assets_error_envelope(nil, args?.release_id ?? args?.id, unwrap_err(repo))
+  }
+  let r = unwrap(repo)
+  var release_id = args?.release_id ?? args?.id
+  if release_id == nil || trim(to_string(release_id)) == "" {
+    let release = __repos_get_latest_release(args + {owner: r.owner, repo: r.name}, cfg)
+    if is_err(release) {
+      return __release_assets_error_envelope(r.full_name, nil, unwrap_err(release))
+    }
+    release_id = unwrap(release)?.id
+  }
+  let assets = __repos_list_release_assets(args + {owner: r.owner, repo: r.name, release_id: release_id}, cfg)
+  if is_err(assets) {
+    return __release_assets_error_envelope(r.full_name, release_id, unwrap_err(assets))
+  }
+  return __release_assets_envelope(r.full_name, release_id, unwrap(assets))
+}
+
 fn __github_merge_queue_entries(args, cfg) {
   let repo = __repo_parts(args)
   if is_err(repo) {
@@ -1862,6 +1948,33 @@ fn __repos_get_text(args, cfg) {
       nil
     },
   }
+}
+
+fn __repos_get_latest_release(args, cfg) {
+  return __github_json(
+    "GET",
+    __github_api_url(cfg.api_base_url, "/repos/" + args.owner + "/" + args.repo + "/releases/latest"),
+    nil,
+    cfg,
+  )
+}
+
+fn __repos_list_release_assets(args, cfg) {
+  let release_id = args?.release_id ?? args?.id
+  if release_id == nil || trim(to_string(release_id)) == "" {
+    return __err("schema_drift", "repos.list_release_assets requires release_id or id")
+  }
+  return __github_json(
+    "GET",
+    __github_api_url(
+      cfg.api_base_url,
+      "/repos/" + args.owner + "/" + args.repo + "/releases/" + to_string(release_id)
+        + "/assets"
+        + __pagination_query(args),
+    ),
+    nil,
+    cfg,
+  )
 }
 
 fn __actions_workflow_dispatch(args, cfg) {
@@ -3209,6 +3322,83 @@ fn __ref_query(args) {
     return ""
   }
   return "?ref=" + url_encode(to_string(args.ref))
+}
+
+fn __api_call(args, cfg) {
+  let path = args?.path
+  if path == nil || trim(to_string(path)) == "" {
+    return __err("schema_drift", "api_call requires path")
+  }
+  let method = uppercase(to_string(args?.method ?? "GET"))
+  let body = args?.body
+  let accept = args?.accept ?? "application/vnd.github+json"
+  let parse_json = args?.parse_json ?? true
+  return __github_request(method, __github_api_url(cfg.api_base_url, path), body, cfg, accept, parse_json)
+}
+
+fn __release_asset_names(assets) {
+  var names = []
+  for asset in assets ?? [] {
+    if asset?.name != nil {
+      names = names + [to_string(asset.name)]
+    }
+  }
+  return names
+}
+
+fn __release_envelope(repo, release) {
+  let assets = release?.assets ?? []
+  return {
+    ok: true,
+    repo: repo,
+    release_id: release?.id,
+    tag_name: release?.tag_name,
+    name: release?.name,
+    draft: release?.draft ?? false,
+    prerelease: release?.prerelease ?? false,
+    url: release?.url,
+    html_url: release?.html_url,
+    published_at: release?.published_at,
+    assets: assets,
+    asset_names: __release_asset_names(assets),
+    raw: release,
+    error: nil,
+  }
+}
+
+fn __release_error_envelope(repo, error) {
+  return {
+    ok: false,
+    repo: repo,
+    release_id: nil,
+    tag_name: nil,
+    name: nil,
+    draft: false,
+    prerelease: false,
+    url: nil,
+    html_url: nil,
+    published_at: nil,
+    assets: [],
+    asset_names: [],
+    raw: nil,
+    error: error,
+  }
+}
+
+fn __release_assets_envelope(repo, release_id, assets) {
+  return {
+    ok: true,
+    repo: repo,
+    release_id: release_id,
+    assets: assets ?? [],
+    asset_names: __release_asset_names(assets ?? []),
+    raw: assets ?? [],
+    error: nil,
+  }
+}
+
+fn __release_assets_error_envelope(repo, release_id, error) {
+  return {ok: false, repo: repo, release_id: release_id, assets: [], asset_names: [], raw: nil, error: error}
 }
 
 @complexity(allow)

--- a/tests/repo_automation_methods.harn
+++ b/tests/repo_automation_methods.harn
@@ -1,9 +1,14 @@
 import {
   actions_workflow_dispatch,
   actions_workflow_runs,
+  api_call,
   call,
+  github_latest_release,
+  github_release_assets,
   pulls_enable_auto_merge,
+  repos_get_latest_release,
   repos_get_text,
+  repos_list_release_assets,
 } from "../src/lib"
 
 pipeline test_repo_automation_methods(task) {
@@ -96,6 +101,87 @@ pipeline test_repo_automation_methods(task) {
   assert_eq(run.conclusion, "success", "workflow run get response")
   http_mock(
     "GET",
+    base + "/repos/octo-org/octo-repo/releases/latest",
+    {
+      status: 200,
+      body: json_stringify(
+        {
+          id: 501,
+          tag_name: "v0.8.4",
+          name: "v0.8.4",
+          draft: false,
+          prerelease: false,
+          html_url: "https://github.com/octo-org/octo-repo/releases/tag/v0.8.4",
+          published_at: "2026-05-09T18:00:00Z",
+          assets: [
+            {id: 1, name: "harn-aarch64-apple-darwin.tar.gz"},
+            {id: 2, name: "harn-x86_64-unknown-linux-gnu.tar.gz"},
+          ],
+        },
+      ),
+      headers: {"x-ratelimit-remaining": "7"},
+    },
+  )
+  let raw_release = repos_get_latest_release("octo-org", "octo-repo", auth)
+  assert_eq(raw_release.tag_name, "v0.8.4", "raw latest release tag")
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/releases/latest",
+    {
+      status: 200,
+      body: json_stringify(
+        {
+          id: 501,
+          tag_name: "v0.8.4",
+          assets: [
+            {id: 1, name: "harn-aarch64-apple-darwin.tar.gz"},
+            {id: 2, name: "harn-x86_64-unknown-linux-gnu.tar.gz"},
+          ],
+        },
+      ),
+      headers: {"x-ratelimit-remaining": "7"},
+    },
+  )
+  let latest = github_latest_release("octo-org", "octo-repo", auth)
+  assert_eq(latest.ok, true, "latest release envelope ok")
+  assert_eq(latest.tag_name, "v0.8.4", "latest release envelope tag")
+  assert_eq(
+    latest.asset_names[1],
+    "harn-x86_64-unknown-linux-gnu.tar.gz",
+    "latest release asset names",
+  )
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/releases/501/assets?per_page=2",
+    {
+      status: 200,
+      body: json_stringify([{id: 1, name: "harn-aarch64-apple-darwin.tar.gz"}]),
+      headers: {"x-ratelimit-remaining": "7"},
+    },
+  )
+  let raw_assets = repos_list_release_assets("octo-org", "octo-repo", 501, auth + {per_page: 2})
+  assert_eq(raw_assets[0].name, "harn-aarch64-apple-darwin.tar.gz", "raw release assets")
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/releases/501/assets?per_page=2",
+    {
+      status: 200,
+      body: json_stringify([{id: 2, name: "harn-x86_64-unknown-linux-gnu.tar.gz"}]),
+      headers: {"x-ratelimit-remaining": "7"},
+    },
+  )
+  let assets = github_release_assets("octo-org", "octo-repo", 501, auth + {per_page: 2})
+  assert_eq(assets.ok, true, "release assets envelope ok")
+  assert_eq(assets.asset_names[0], "harn-x86_64-unknown-linux-gnu.tar.gz", "release assets names")
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/releases/latest",
+    {status: 200, body: json_stringify({tag_name: "v0.8.4"}), headers: {"x-ratelimit-remaining": "7"}},
+  )
+  let raw = api_call("/repos/octo-org/octo-repo/releases/latest", "GET", nil, auth)
+  assert_eq(raw.tag_name, "v0.8.4", "raw api_call works as compatibility escape hatch")
+  http_mock(
+    "GET",
     base + "/repos/octo-org/octo-repo/pulls/7",
     {
       status: 200,
@@ -138,7 +224,7 @@ pipeline test_repo_automation_methods(task) {
   assert_eq(auto_merge.requested_method, "SQUASH", "auto-merge merge method normalized")
   let calls = http_mock_calls()
   let dispatch_body = json_parse(calls[1].body)
-  let mutation_body = json_parse(calls[5].body)
+  let mutation_body = json_parse(calls[10].body)
   let mutation_vars = mutation_body.get("variables")
   assert_eq(dispatch_body.get("return_run_details"), true, "workflow dispatch asks for run details")
   assert_eq(mutation_vars.get("pullRequestId"), "PR_node_7", "auto-merge mutation uses PR node id")


### PR DESCRIPTION
## Summary
- add release metadata and release asset outbound methods
- add api_call as the raw REST escape hatch for stdlib compatibility
- document permissions and stable release envelopes

## Verification
- harn fmt --check src tests
- harn check src/lib.harn
- harn lint src/lib.harn
- harn connector check . --provider github
- for test in tests/*.harn; do harn run "$test" || exit 1; done