### PR TITLE
Polish GitHub connector rate-limit handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ Common option fields:
 - Auth options (`installation_token`, `app_id`/`installation_id`/`private_key_secret`,
   `api_base_url`, `allow_gh_auth_fallback`, ...) are accepted and forwarded
   through the existing `call(...)` configuration path.
+- `timeout_ms` is forwarded to outbound GitHub HTTP requests, and
+  `rate_limit_max_sleep_seconds` caps any single rate-limit reset wait
+  (default `60`; set `0` in CI to fail fast instead of sleeping).
 - `poll_interval_ms`, `timeout_ms`, and `max_attempts` control the wait
   helpers. `max_attempts` overrides the timeout when set, which keeps tests
   deterministic without wall-clock dependence.
@@ -373,8 +376,8 @@ silently depend on a user-scoped local CLI session.
 - Installation tokens are cached until the configured refresh window, refreshed
   under a mutex, invalidated after a `401`, and retried once.
 - GitHub primary rate-limit responses with short reset windows are retried once;
-  long reset windows return a `rate_limited` error instead of sleeping in CI or
-  webhook paths.
+  resets beyond `rate_limit_max_sleep_seconds` return a `rate_limited` error
+  instead of sleeping in CI or webhook paths.
 - Outbound errors carry deterministic `category` values for typed callers:
   `auth`, `permission`, `rate_limit`, `branch_protection`, `merge_queue`,
   `checks_pending`, `checks_failed`, `network`, and `schema_drift`.

--- a/harn.toml
+++ b/harn.toml
@@ -12,6 +12,7 @@ default = "src/lib.harn"
 [[providers]]
 id = "github"
 connector = { harn = "src/lib.harn" }
+capabilities = ["webhook", "rate_limit", "pagination", "graphql"]
 
 [providers.setup]
 auth_type = "github-app"

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -78,6 +78,8 @@ let DEFAULT_JWT_BACKDATE_SECONDS = 60
 
 let DEFAULT_JWT_TTL_SECONDS = 600
 
+let DEFAULT_RATE_LIMIT_MAX_SLEEP_SECONDS = 60
+
 var GITHUB_STATE = {initialized: false, active: false, bindings: {}, ctx: {}}
 
 /** Return this connector's Harn provider id. */
@@ -4146,6 +4148,10 @@ fn __outbound_config(args) {
         installation_token: to_string(direct_token),
         token_mode: "direct",
         installation_id: args?.installation_id,
+        now: args?.now,
+        timeout_ms: args?.timeout_ms,
+        rate_limit_max_sleep_seconds: args?.rate_limit_max_sleep_seconds
+          ?? DEFAULT_RATE_LIMIT_MAX_SLEEP_SECONDS,
       },
     )
   }
@@ -4164,6 +4170,10 @@ fn __outbound_config(args) {
           installation_token: to_string(unwrap(gh_token)),
           token_mode: "gh_auth",
           installation_id: nil,
+          now: args?.now,
+          timeout_ms: args?.timeout_ms,
+          rate_limit_max_sleep_seconds: args?.rate_limit_max_sleep_seconds
+            ?? DEFAULT_RATE_LIMIT_MAX_SLEEP_SECONDS,
         },
       )
     }
@@ -4184,6 +4194,8 @@ fn __outbound_config(args) {
     token_refresh_skew_seconds: args?.token_refresh_skew_seconds ?? DEFAULT_TOKEN_REFRESH_SKEW_SECONDS,
     now: args?.now,
     timeout_ms: args?.timeout_ms,
+    rate_limit_max_sleep_seconds: args?.rate_limit_max_sleep_seconds
+      ?? DEFAULT_RATE_LIMIT_MAX_SLEEP_SECONDS,
   }
   let token_result = installation_token(resolved)
   if is_err(token_result) {
@@ -4209,6 +4221,7 @@ fn __config_keys() {
     "token_refresh_skew_seconds",
     "now",
     "timeout_ms",
+    "rate_limit_max_sleep_seconds",
     "allow_gh_auth_fallback",
     "gh_auth_fallback",
     "gh_token",
@@ -4445,6 +4458,9 @@ fn __github_request(method, url, body, cfg, accept, parse_json) {
       options["body"] = json_stringify(body)
       options.headers["Content-Type"] = "application/json"
     }
+    if cfg?.timeout_ms != nil {
+      options["timeout_ms"] = cfg.timeout_ms
+    }
     let response_result = try {
       http_request(method, url, options)
     }
@@ -4462,7 +4478,7 @@ fn __github_request(method, url, body, cfg, accept, parse_json) {
       current_token = to_string(refreshed)
       continue
     }
-    let limited = __maybe_wait_for_rate_limit(response)
+    let limited = __maybe_wait_for_rate_limit(response, cfg)
     if is_err(limited) {
       return limited
     }
@@ -4536,7 +4552,7 @@ fn __is_rate_limit_response(response) {
   return remaining != nil && trim(to_string(remaining)) == "0"
 }
 
-fn __maybe_wait_for_rate_limit(response) {
+fn __maybe_wait_for_rate_limit(response, cfg) {
   let remaining = __response_header(response.headers ?? {}, "x-ratelimit-remaining")
   if remaining == nil || trim(to_string(remaining)) != "0" {
     return Ok(false)
@@ -4551,9 +4567,17 @@ fn __maybe_wait_for_rate_limit(response) {
   if is_err(parsed_reset) {
     return Ok(true)
   }
-  let wait_seconds = unwrap(parsed_reset) - to_int(timestamp())
-  if wait_seconds > 60 {
-    return __err("rate_limited", "github API rate limit reset is more than 60 seconds away")
+  let wait_seconds = unwrap(parsed_reset) - __now_seconds(cfg ?? {})
+  let max_sleep = max(
+    0,
+    to_int(cfg?.rate_limit_max_sleep_seconds ?? DEFAULT_RATE_LIMIT_MAX_SLEEP_SECONDS)
+      ?? DEFAULT_RATE_LIMIT_MAX_SLEEP_SECONDS,
+  )
+  if wait_seconds > max_sleep {
+    return __err(
+      "rate_limited",
+      "github API rate limit reset is more than " + to_string(max_sleep) + " seconds away",
+    )
   }
   if wait_seconds > 0 {
     sleep(wait_seconds * 1000)
@@ -4585,6 +4609,8 @@ fn __resolve_token_config(config) {
       token_refresh_skew_seconds: config?.token_refresh_skew_seconds ?? DEFAULT_TOKEN_REFRESH_SKEW_SECONDS,
       now: config?.now,
       timeout_ms: config?.timeout_ms,
+      rate_limit_max_sleep_seconds: config?.rate_limit_max_sleep_seconds
+        ?? DEFAULT_RATE_LIMIT_MAX_SLEEP_SECONDS,
     },
   )
 }
@@ -4687,5 +4713,5 @@ fn __now_seconds(config) {
   if config?.now != nil {
     return to_int(config.now)
   }
-  return to_int(timestamp())
+  return to_int(date_parse(date_now_iso()))
 }

--- a/tests/call_smoke.harn
+++ b/tests/call_smoke.harn
@@ -157,7 +157,7 @@ pipeline default() {
         {
           status: 403,
           body: "{\"message\":\"rate limited\"}",
-          headers: {"x-ratelimit-remaining": "0", "x-ratelimit-reset": to_string(to_int(timestamp()) - 1)},
+          headers: {"x-ratelimit-remaining": "0", "x-ratelimit-reset": "1"},
         },
         {status: 200, body: "[{\"filename\":\"src/lib.rs\"}]", headers: {"x-ratelimit-remaining": "8"}},
       ],
@@ -181,7 +181,7 @@ pipeline default() {
     {
       status: 403,
       body: "{\"message\":\"rate limited\"}",
-      headers: {"x-ratelimit-remaining": "0", "x-ratelimit-reset": to_string(to_int(timestamp()) + 120)},
+      headers: {"x-ratelimit-remaining": "0", "x-ratelimit-reset": "1700000001"},
     },
   )
   let capped = call(
@@ -192,6 +192,8 @@ pipeline default() {
       owner: "octo-org",
       repo: "octo-repo",
       path: "README.md",
+      rate_limit_max_sleep_seconds: 0,
+      now: 1700000000,
     },
   )
   assert(is_err(capped), "rate-limit cap rejects")


### PR DESCRIPTION
## Summary
- advertise GitHub connector capabilities from the current Harn authoring guide
- forward outbound timeout_ms consistently across auth modes
- make primary rate-limit retry caps configurable and deterministic under tests
- update README operational notes for the new knobs

## Verification
- harn fmt --check src tests && harn lint src && harn check src/lib.harn && harn connector check .
- for test in tests/*.harn; do harn run "" || exit 1; done
- harn connector test "/Users/ksinder/.codex/worktrees/56fb/harn-github-connector"
- patched Harn CLI: harn connector test .