### PR TITLE
Security sweep 2026-05-23: harn-github-connector

### DIFF
--- a/harn.toml
+++ b/harn.toml
@@ -46,8 +46,8 @@ version = 1
 provider = "github"
 name = "issues opened webhook"
 kind = "webhook"
-headers = { "X-GitHub-Event" = "issues", "X-GitHub-Delivery" = "delivery-contract-issues", "X-Hub-Signature-256" = "sha256=28d67d2d05e00e5cc1ac60de0f958c528d74ca6d597a4c7ef23c6591ac3cec86", "content-type" = "application/json" }
-metadata = { signing_secret = "test-signing-secret" }
+headers = { "X-GitHub-Event" = "issues", "X-GitHub-Delivery" = "delivery-contract-issues", "X-Hub-Signature-256" = "sha256=3911dfdeeb1a21a53e384641c841f225586a22f775b4f071d8c1953f5bb8ecae", "content-type" = "application/json" }
+metadata = { secret_ids = { signing_secret = "github/signing_secret" } }
 body = '''{"action":"opened","issue":{"number":7,"title":"Connector fixture issue","state":"open","html_url":"https://github.com/octo-org/octo-repo/issues/7","created_at":"2026-04-20T14:00:00Z","updated_at":"2026-04-20T14:00:00Z","user":{"id":1001,"login":"octocat","type":"User"}},"repository":{"name":"octo-repo","full_name":"octo-org/octo-repo","owner":{"id":2001,"login":"octo-org","type":"Organization"}},"sender":{"id":1001,"login":"octocat","type":"User"},"installation":{"id":3001}}'''
 expect_type = "event"
 expect_kind = "issues"
@@ -72,8 +72,8 @@ expect_event_count = 1
 provider = "github"
 name = "pull request opened webhook"
 kind = "webhook"
-headers = { "X-GitHub-Event" = "pull_request", "X-GitHub-Delivery" = "delivery-contract-pr", "X-Hub-Signature-256" = "sha256=8eb23983613140177d886d50884e4ec3cda226b4fd9b2a9345ee6f1a17d354ae", "content-type" = "application/json" }
-metadata = { signing_secret = "test-signing-secret" }
+headers = { "X-GitHub-Event" = "pull_request", "X-GitHub-Delivery" = "delivery-contract-pr", "X-Hub-Signature-256" = "sha256=7088174c1a62d93fc7cc65a781db02a383df27bc8af5956007626edc1d43b29e", "content-type" = "application/json" }
+metadata = { secret_ids = { signing_secret = "github/signing_secret" } }
 body = '''{"action":"opened","number":42,"pull_request":{"number":42,"title":"Add connector fixture","state":"open","html_url":"https://github.com/octo-org/octo-repo/pull/42","created_at":"2026-04-20T12:00:00Z","updated_at":"2026-04-20T12:05:00Z","user":{"id":1001,"login":"octocat","type":"User"}},"repository":{"name":"octo-repo","full_name":"octo-org/octo-repo","owner":{"id":2001,"login":"octo-org","type":"Organization"}},"sender":{"id":1001,"login":"octocat","type":"User"},"installation":{"id":3001}}'''
 expect_type = "event"
 expect_kind = "pull_request"
@@ -85,8 +85,8 @@ expect_event_count = 1
 provider = "github"
 name = "issue comment created webhook"
 kind = "webhook"
-headers = { "X-GitHub-Event" = "issue_comment", "X-GitHub-Delivery" = "delivery-contract-comment", "X-Hub-Signature-256" = "sha256=86a06acb530d546e22016704a5f86d3b9fe941dedebb6c89df790c0c1486da6d", "content-type" = "application/json" }
-metadata = { signing_secret = "test-signing-secret" }
+headers = { "X-GitHub-Event" = "issue_comment", "X-GitHub-Delivery" = "delivery-contract-comment", "X-Hub-Signature-256" = "sha256=6198a912f4ea39217c2e2f6d17dd817cf41353b4182fb9d6ef91a37200862912", "content-type" = "application/json" }
+metadata = { secret_ids = { signing_secret = "github/signing_secret" } }
 body = '''{"action":"created","issue":{"number":7,"title":"Connector fixture issue","state":"open","html_url":"https://github.com/octo-org/octo-repo/issues/7","created_at":"2026-04-20T14:00:00Z","updated_at":"2026-04-20T15:00:00Z","user":{"id":1001,"login":"octocat","type":"User"}},"comment":{"id":9001,"body":"Looks good from the fixture.","html_url":"https://github.com/octo-org/octo-repo/issues/7#issuecomment-9001","created_at":"2026-04-20T15:00:00Z","updated_at":"2026-04-20T15:00:00Z","user":{"id":1002,"login":"reviewer","type":"User"}},"repository":{"name":"octo-repo","full_name":"octo-org/octo-repo","owner":{"id":2001,"login":"octo-org","type":"Organization"}},"sender":{"id":1002,"login":"reviewer","type":"User"},"installation":{"id":3001}}'''
 expect_type = "event"
 expect_kind = "issue_comment"
@@ -98,8 +98,8 @@ expect_event_count = 1
 provider = "github"
 name = "pull request review submitted webhook"
 kind = "webhook"
-headers = { "X-GitHub-Event" = "pull_request_review", "X-GitHub-Delivery" = "delivery-contract-review", "X-Hub-Signature-256" = "sha256=c70b2329288fe92a7850da63e4b9d72abe76ee3725918b7e288f9121d8225167", "content-type" = "application/json" }
-metadata = { signing_secret = "test-signing-secret" }
+headers = { "X-GitHub-Event" = "pull_request_review", "X-GitHub-Delivery" = "delivery-contract-review", "X-Hub-Signature-256" = "sha256=bcc6d9aaf5de9e549ad716958f19806be0b6f715f48aba93d9403d149d83a4a6", "content-type" = "application/json" }
+metadata = { secret_ids = { signing_secret = "github/signing_secret" } }
 body = '''{"action":"submitted","pull_request":{"number":42,"title":"Add connector fixture","state":"open","html_url":"https://github.com/octo-org/octo-repo/pull/42","created_at":"2026-04-20T12:00:00Z","updated_at":"2026-04-20T12:10:00Z","user":{"id":1001,"login":"octocat","type":"User"}},"review":{"id":7001,"state":"approved","html_url":"https://github.com/octo-org/octo-repo/pull/42#pullrequestreview-7001","submitted_at":"2026-04-20T12:11:00Z","user":{"id":1002,"login":"reviewer","type":"User"}},"repository":{"name":"octo-repo","full_name":"octo-org/octo-repo","owner":{"id":2001,"login":"octo-org","type":"Organization"}},"sender":{"id":1002,"login":"reviewer","type":"User"},"installation":{"id":3001}}'''
 expect_type = "event"
 expect_kind = "pull_request_review"
@@ -111,8 +111,8 @@ expect_event_count = 1
 provider = "github"
 name = "push webhook"
 kind = "webhook"
-headers = { "X-GitHub-Event" = "push", "X-GitHub-Delivery" = "delivery-contract-push", "X-Hub-Signature-256" = "sha256=3b7ce87af63d0fd77a5b3a19f9cea4cbfc82794166fea17aa8ade634c0ed2108", "content-type" = "application/json" }
-metadata = { signing_secret = "test-signing-secret" }
+headers = { "X-GitHub-Event" = "push", "X-GitHub-Delivery" = "delivery-contract-push", "X-Hub-Signature-256" = "sha256=aa7e9b6d9d027210514c8cf7df2371f498bd720a9a8e305e311629668c40ef4c", "content-type" = "application/json" }
+metadata = { secret_ids = { signing_secret = "github/signing_secret" } }
 body = '''{"ref":"refs/heads/main","before":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","after":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","head_commit":{"id":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","message":"Update fixture","timestamp":"2026-04-20T13:00:00Z"},"commits":[{"id":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","message":"Update fixture","timestamp":"2026-04-20T13:00:00Z"}],"distinct_size":1,"pusher":{"name":"octocat","email":"octocat@example.test"},"repository":{"name":"octo-repo","full_name":"octo-org/octo-repo","owner":{"id":2001,"login":"octo-org","type":"Organization"},"pushed_at":"2026-04-20T13:00:00Z"},"sender":{"id":1001,"login":"octocat","type":"User"},"installation":{"id":3001}}'''
 expect_type = "event"
 expect_kind = "push"
@@ -124,8 +124,8 @@ expect_event_count = 1
 provider = "github"
 name = "workflow run completed webhook"
 kind = "webhook"
-headers = { "X-GitHub-Event" = "workflow_run", "X-GitHub-Delivery" = "delivery-contract-workflow", "X-Hub-Signature-256" = "sha256=24119c9f6faf40ae6802ce4efd0fb63d026d3eb871f63f4bac54fc2c4eb7696c", "content-type" = "application/json" }
-metadata = { signing_secret = "test-signing-secret" }
+headers = { "X-GitHub-Event" = "workflow_run", "X-GitHub-Delivery" = "delivery-contract-workflow", "X-Hub-Signature-256" = "sha256=f6b1be5fe2eff0ee9c6292faee8b0467a5a76c883fa6a895d3519f0fc012ae24", "content-type" = "application/json" }
+metadata = { secret_ids = { signing_secret = "github/signing_secret" } }
 body = '''{"action":"completed","workflow_run":{"id":6001,"name":"Harn CI","status":"completed","conclusion":"success","html_url":"https://github.com/octo-org/octo-repo/actions/runs/6001","run_started_at":"2026-04-20T16:00:00Z","created_at":"2026-04-20T16:00:00Z","updated_at":"2026-04-20T16:04:00Z"},"repository":{"name":"octo-repo","full_name":"octo-org/octo-repo","owner":{"id":2001,"login":"octo-org","type":"Organization"}},"sender":{"id":1001,"login":"octocat","type":"User"},"installation":{"id":3001}}'''
 expect_type = "event"
 expect_kind = "workflow_run"
@@ -137,8 +137,8 @@ expect_event_count = 1
 provider = "github"
 name = "deployment status created webhook"
 kind = "webhook"
-headers = { "X-GitHub-Event" = "deployment_status", "X-GitHub-Delivery" = "delivery-contract-deployment", "X-Hub-Signature-256" = "sha256=1e3f77c1cc99c58bb4a94d95f9523d2efd43ba958b9f86fcfc34663d0b1bd560", "content-type" = "application/json" }
-metadata = { signing_secret = "test-signing-secret" }
+headers = { "X-GitHub-Event" = "deployment_status", "X-GitHub-Delivery" = "delivery-contract-deployment", "X-Hub-Signature-256" = "sha256=cd4482b15d5cb5257a8a9c4ade553741cbfbea71b3026af8b4c89e4e4373db9b", "content-type" = "application/json" }
+metadata = { secret_ids = { signing_secret = "github/signing_secret" } }
 body = '''{"action":"created","deployment":{"id":5001,"environment":"staging","created_at":"2026-04-20T17:00:00Z"},"deployment_status":{"id":5002,"state":"in_progress","target_url":"https://deployments.example.test/octo-repo/5002","created_at":"2026-04-20T17:01:00Z","updated_at":"2026-04-20T17:01:00Z"},"repository":{"name":"octo-repo","full_name":"octo-org/octo-repo","owner":{"id":2001,"login":"octo-org","type":"Organization"}},"sender":{"id":1001,"login":"octocat","type":"User"},"installation":{"id":3001}}'''
 expect_type = "event"
 expect_kind = "deployment_status"
@@ -150,8 +150,8 @@ expect_event_count = 1
 provider = "github"
 name = "check run completed webhook"
 kind = "webhook"
-headers = { "X-GitHub-Event" = "check_run", "X-GitHub-Delivery" = "delivery-contract-check-run", "X-Hub-Signature-256" = "sha256=38924f1ae5997b3b06c5bfab26494a59df0472dce44711f273406d8abf7b5cca", "content-type" = "application/json" }
-metadata = { signing_secret = "test-signing-secret" }
+headers = { "X-GitHub-Event" = "check_run", "X-GitHub-Delivery" = "delivery-contract-check-run", "X-Hub-Signature-256" = "sha256=3d9f90a7df7fb7344a7a8161da886cb381575902dcea35231a5f16c9bf3ac591", "content-type" = "application/json" }
+metadata = { secret_ids = { signing_secret = "github/signing_secret" } }
 body = '''{"action":"completed","check_run":{"id":8001,"name":"Harn CI","status":"completed","conclusion":"success","html_url":"https://github.com/octo-org/octo-repo/runs/8001","started_at":"2026-04-20T16:00:00Z","completed_at":"2026-04-20T16:03:00Z"},"repository":{"name":"octo-repo","full_name":"octo-org/octo-repo","owner":{"id":2001,"login":"octo-org","type":"Organization"}},"sender":{"id":1001,"login":"octocat","type":"User"},"installation":{"id":3001}}'''
 expect_type = "event"
 expect_kind = "check_run"
@@ -163,8 +163,8 @@ expect_event_count = 1
 provider = "github"
 name = "check suite requested webhook"
 kind = "webhook"
-headers = { "X-GitHub-Event" = "check_suite", "X-GitHub-Delivery" = "delivery-contract-check-suite-requested", "X-Hub-Signature-256" = "sha256=ebca4fa04e40e59bb15606ceb8ded0b1ad447974cc094ff6a125236b8f461067", "content-type" = "application/json" }
-metadata = { signing_secret = "test-signing-secret" }
+headers = { "X-GitHub-Event" = "check_suite", "X-GitHub-Delivery" = "delivery-contract-check-suite-requested", "X-Hub-Signature-256" = "sha256=a3eb54f02ccef8aa06719c2c4547d0de4069296996fee2da47bacf7d8e79d942", "content-type" = "application/json" }
+metadata = { secret_ids = { signing_secret = "github/signing_secret" } }
 body = '''{"action":"requested","check_suite":{"id":8101,"status":"queued","conclusion":null,"head_branch":"feature/connector-fixture","head_sha":"cccccccccccccccccccccccccccccccccccccccc","pull_requests":[{"number":42,"head":{"ref":"feature/connector-fixture","sha":"cccccccccccccccccccccccccccccccccccccccc"},"base":{"ref":"main","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}],"created_at":"2026-04-20T15:59:00Z","updated_at":"2026-04-20T15:59:00Z"},"repository":{"name":"octo-repo","full_name":"octo-org/octo-repo","owner":{"id":2001,"login":"octo-org","type":"Organization"}},"sender":{"id":1001,"login":"octocat","type":"User"},"installation":{"id":3001}}'''
 expect_type = "event"
 expect_kind = "check_suite"
@@ -176,8 +176,8 @@ expect_event_count = 1
 provider = "github"
 name = "status success webhook"
 kind = "webhook"
-headers = { "X-GitHub-Event" = "status", "X-GitHub-Delivery" = "delivery-contract-status-success", "X-Hub-Signature-256" = "sha256=872533387fc2c4e2e11681288d212c716c3a5fe35e7771b6ec6ba034709993b8", "content-type" = "application/json" }
-metadata = { signing_secret = "test-signing-secret" }
+headers = { "X-GitHub-Event" = "status", "X-GitHub-Delivery" = "delivery-contract-status-success", "X-Hub-Signature-256" = "sha256=1752fa4ec35d1059b9323e341e3ea7c67791c4be78a810ae9bd683757a6ddd7d", "content-type" = "application/json" }
+metadata = { secret_ids = { signing_secret = "github/signing_secret" } }
 body = '''{"id":9101,"sha":"cccccccccccccccccccccccccccccccccccccccc","state":"success","context":"legacy/status","target_url":"https://ci.example.test/octo-repo/9101","description":"Legacy CI passed","branches":[{"name":"main"}],"created_at":"2026-04-20T16:05:00Z","updated_at":"2026-04-20T16:05:00Z","repository":{"name":"octo-repo","full_name":"octo-org/octo-repo","owner":{"id":2001,"login":"octo-org","type":"Organization"}},"sender":{"id":1001,"login":"octocat","type":"User"},"installation":{"id":3001}}'''
 expect_type = "event"
 expect_kind = "status"
@@ -189,8 +189,8 @@ expect_event_count = 1
 provider = "github"
 name = "merge group checks requested webhook"
 kind = "webhook"
-headers = { "X-GitHub-Event" = "merge_group", "X-GitHub-Delivery" = "delivery-contract-merge-group-checks-requested", "X-Hub-Signature-256" = "sha256=e9a802a5469f1cd73c92a06b26d5f18e71689381c172184a3817380fe145c98f", "content-type" = "application/json" }
-metadata = { signing_secret = "test-signing-secret" }
+headers = { "X-GitHub-Event" = "merge_group", "X-GitHub-Delivery" = "delivery-contract-merge-group-checks-requested", "X-Hub-Signature-256" = "sha256=403428239c13d59fc3b8e28cee97a5b832cd5e64ecd8fa0db12036ee09e3a21a", "content-type" = "application/json" }
+metadata = { secret_ids = { signing_secret = "github/signing_secret" } }
 body = '''{"action":"checks_requested","merge_group":{"id":9201,"head_ref":"gh-readonly-queue/main/pr-42-cccccccccccc","head_sha":"dddddddddddddddddddddddddddddddddddddddd","base_ref":"main","base_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head_commit":{"timestamp":"2026-04-20T16:06:00Z"},"pull_requests":[{"number":42,"head":{"ref":"feature/connector-fixture","sha":"cccccccccccccccccccccccccccccccccccccccc"},"base":{"ref":"main","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}]},"repository":{"name":"octo-repo","full_name":"octo-org/octo-repo","owner":{"id":2001,"login":"octo-org","type":"Organization"}},"sender":{"id":1001,"login":"octocat","type":"User"},"installation":{"id":3001}}'''
 expect_type = "event"
 expect_kind = "merge_group"
@@ -202,8 +202,8 @@ expect_event_count = 1
 provider = "github"
 name = "installation suspend webhook"
 kind = "webhook"
-headers = { "X-GitHub-Event" = "installation", "X-GitHub-Delivery" = "delivery-contract-installation-suspend", "X-Hub-Signature-256" = "sha256=67cab28a2624f01d86151e5a87cc667436d4931387b95d51c27660d22b8c46da", "content-type" = "application/json" }
-metadata = { signing_secret = "test-signing-secret" }
+headers = { "X-GitHub-Event" = "installation", "X-GitHub-Delivery" = "delivery-contract-installation-suspend", "X-Hub-Signature-256" = "sha256=8c33716de28c45801106249d84cf66be84f3d66ebc5da7e7b1313775bfb559f8", "content-type" = "application/json" }
+metadata = { secret_ids = { signing_secret = "github/signing_secret" } }
 body = '''{"action":"suspend","installation":{"id":3001,"account":{"id":2001,"login":"octo-org","type":"Organization"},"repository_selection":"selected","suspended_at":"2026-04-20T18:00:00Z","suspended_by":{"id":1003,"login":"admin","type":"User"}},"repositories":[{"id":4001,"name":"octo-repo","full_name":"octo-org/octo-repo","private":false}],"sender":{"id":1003,"login":"admin","type":"User"}}'''
 expect_type = "event"
 expect_kind = "installation"
@@ -215,8 +215,8 @@ expect_event_count = 1
 provider = "github"
 name = "installation deleted webhook"
 kind = "webhook"
-headers = { "X-GitHub-Event" = "installation", "X-GitHub-Delivery" = "delivery-contract-installation-deleted", "X-Hub-Signature-256" = "sha256=74b770dbd0897fc170100b27f14b5018ad9049cffe395364a54c6f74a5ce7375", "content-type" = "application/json" }
-metadata = { signing_secret = "test-signing-secret" }
+headers = { "X-GitHub-Event" = "installation", "X-GitHub-Delivery" = "delivery-contract-installation-deleted", "X-Hub-Signature-256" = "sha256=e006d99397e2322d86bfe62fa111ee12336c7b5c17f5b1c64ed3bbbdef5d79bf", "content-type" = "application/json" }
+metadata = { secret_ids = { signing_secret = "github/signing_secret" } }
 body = '''{"action":"deleted","installation":{"id":3001,"account":{"id":2001,"login":"octo-org","type":"Organization"},"repository_selection":"selected"},"repositories":[{"id":4001,"name":"octo-repo","full_name":"octo-org/octo-repo","private":false}],"sender":{"id":1003,"login":"admin","type":"User"}}'''
 expect_type = "event"
 expect_kind = "installation"
@@ -228,8 +228,8 @@ expect_event_count = 1
 provider = "github"
 name = "installation repositories removed webhook"
 kind = "webhook"
-headers = { "X-GitHub-Event" = "installation_repositories", "X-GitHub-Delivery" = "delivery-contract-installation-repositories-removed", "X-Hub-Signature-256" = "sha256=6c9518ef23ec3fdc5bb028b07d7c4e74b3ec6c55098dd3ff9eb4e1ad05de250e", "content-type" = "application/json" }
-metadata = { signing_secret = "test-signing-secret" }
+headers = { "X-GitHub-Event" = "installation_repositories", "X-GitHub-Delivery" = "delivery-contract-installation-repositories-removed", "X-Hub-Signature-256" = "sha256=caa002bdf71a164de8d6c287d27c24c0312d0e3a9afd3e36e1f008ce84abee57", "content-type" = "application/json" }
+metadata = { secret_ids = { signing_secret = "github/signing_secret" } }
 body = '''{"action":"removed","installation":{"id":3001,"account":{"id":2001,"login":"octo-org","type":"Organization"},"repository_selection":"selected"},"repository_selection":"selected","repositories_added":[],"repositories_removed":[{"id":4001,"name":"octo-repo","full_name":"octo-org/octo-repo","private":false}],"sender":{"id":1003,"login":"admin","type":"User"}}'''
 expect_type = "event"
 expect_kind = "installation_repositories"
@@ -242,7 +242,7 @@ provider = "github"
 name = "invalid signature reject"
 kind = "webhook"
 headers = { "X-GitHub-Event" = "issues", "X-GitHub-Delivery" = "delivery-contract-invalid", "X-Hub-Signature-256" = "sha256=0000000000000000000000000000000000000000000000000000000000000000", "content-type" = "application/json" }
-metadata = { signing_secret = "test-signing-secret" }
+metadata = { secret_ids = { signing_secret = "github/signing_secret" } }
 body = '''{"action":"opened","issue":{"number":7,"title":"Connector fixture issue","state":"open","html_url":"https://github.com/octo-org/octo-repo/issues/7","created_at":"2026-04-20T14:00:00Z","updated_at":"2026-04-20T14:00:00Z","user":{"id":1001,"login":"octocat","type":"User"}},"repository":{"name":"octo-repo","full_name":"octo-org/octo-repo","owner":{"id":2001,"login":"octo-org","type":"Organization"}},"sender":{"id":1001,"login":"octocat","type":"User"},"installation":{"id":3001}}'''
 expect_type = "reject"
 expect_event_count = 0

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -86,6 +86,8 @@ let DEFAULT_JWT_TTL_SECONDS = 600
 
 let DEFAULT_RATE_LIMIT_MAX_SLEEP_SECONDS = 60
 
+let MAX_BODY_BYTES = 1048576
+
 var GITHUB_STATE = {initialized: false, active: false, bindings: {}, ctx: {}}
 
 /** Return this connector's Harn provider id. */
@@ -192,11 +194,15 @@ pub fn shutdown() {
 /** Verify and normalize a raw GitHub webhook request into NormalizeResult v1. */
 pub fn normalize_inbound(raw) {
   let body_text = raw?.body_text ?? raw?.body ?? ""
+  if len(body_text) > MAX_BODY_BYTES {
+    return __reject(413, "payload_too_large", "github webhook body exceeds 1 MiB cap")
+  }
   let headers = raw?.headers ?? {}
   let verified = __verify_github_signature(raw, headers, body_text)
   if is_err(verified) {
     return __reject_err(unwrap_err(verified))
   }
+  let signature_status = unwrap(verified)
   let parsed = try {
     json_parse(body_text)
   }
@@ -211,7 +217,7 @@ pub fn normalize_inbound(raw) {
   if !contains(GITHUB_WEBHOOK_EVENTS, event_kind) {
     return __reject(400, "unsupported_event", "unsupported GitHub event type `" + to_string(event_kind) + "`")
   }
-  let event = __build_event(event_kind, payload, raw, headers)
+  let event = __build_event(event_kind, payload, raw, headers, signature_status)
   return {type: "event", event: event}
 }
 
@@ -2657,15 +2663,6 @@ fn __event_kind(raw, headers) {
 }
 
 fn __signing_secret(raw) {
-  let direct = raw?.signing_secret ?? raw?.secret ?? raw?.webhook_secret
-    ?? raw?.config?.signing_secret
-    ?? raw?.secrets?.signing_secret
-    ?? raw?.metadata?.signing_secret
-    ?? raw?.metadata?.secrets?.signing_secret
-    ?? raw?.metadata?.config?.signing_secret
-  if direct != nil && trim(to_string(direct)) != "" {
-    return to_string(direct)
-  }
   let state = __state()
   let ctx_secret = state?.ctx?.signing_secret ?? state?.ctx?.secrets?.signing_secret
   if ctx_secret != nil && trim(to_string(ctx_secret)) != "" {
@@ -2675,14 +2672,6 @@ fn __signing_secret(raw) {
   let binding_id = raw?.metadata?.binding_id ?? raw?.binding_id
   if binding_id != nil {
     let binding = bindings.get(binding_id)
-    let binding_secret = binding?.signing_secret ?? binding?.secrets?.signing_secret ?? binding?.config?.signing_secret
-    if binding_secret != nil && trim(to_string(binding_secret)) != "" {
-      return to_string(binding_secret)
-    }
-  }
-  let values = bindings.values()
-  if len(values) == 1 {
-    let binding = values[0]
     let binding_secret = binding?.signing_secret ?? binding?.secrets?.signing_secret ?? binding?.config?.signing_secret
     if binding_secret != nil && trim(to_string(binding_secret)) != "" {
       return to_string(binding_secret)
@@ -2698,14 +2687,7 @@ fn __signing_secret(raw) {
 
 fn __signing_secret_id(raw) {
   let metadata = raw?.metadata ?? {}
-  let id = raw?.signing_secret_id ?? raw?.signing_secret_secret
-    ?? raw?.config?.signing_secret_id
-    ?? raw?.config?.signing_secret_secret
-    ?? raw?.secrets?.signing_secret_id
-    ?? metadata?.signing_secret_id
-    ?? metadata?.signing_secret_secret
-    ?? metadata?.secret_ids?.signing_secret
-    ?? metadata?.config?.secret_ids?.signing_secret
+  let id = metadata?.secret_ids?.signing_secret ?? metadata?.config?.secret_ids?.signing_secret
   let direct_id = __secret_id_candidate(id, "signing_secret")
   if direct_id != nil {
     return direct_id
@@ -2715,10 +2697,6 @@ fn __signing_secret_id(raw) {
   if binding_id != nil {
     let binding = bindings.get(binding_id)
     return __binding_signing_secret_id(binding)
-  }
-  let values = bindings.values()
-  if len(values) == 1 {
-    return __binding_signing_secret_id(values[0])
   }
   return nil
 }
@@ -2777,11 +2755,11 @@ fn __verify_github_signature(raw, headers, body_text) {
   if !constant_time_eq(expected, actual) {
     return __err("invalid_signature", "x-hub-signature-256 did not match the request body")
   }
-  return Ok(true)
+  return Ok("verified")
 }
 
 @complexity(allow)
-fn __build_event(event_kind, payload, raw, headers) {
+fn __build_event(event_kind, payload, raw, headers, signature_status) {
   let repo = __repo(payload)
   let occurred_at = __occurred_at(event_kind, payload, raw)
   let delivery_id = __header(headers, "x-github-delivery")
@@ -2793,10 +2771,17 @@ fn __build_event(event_kind, payload, raw, headers) {
     occurred_at: occurred_at,
     dedupe_key: dedupe_key,
     delivery_id: delivery_id,
-    signature_status: {state: "verified"},
+    signature_status: __signature_status(signature_status),
     payload: normalized_payload,
     headers: {"x-github-event": event_kind, "x-github-delivery": delivery_id},
   }
+}
+
+fn __signature_status(status) {
+  if status == "verified" || status == "signed" {
+    return {state: "verified"}
+  }
+  return {state: "unsigned"}
 }
 
 fn __dedupe_key(event_kind, payload, repo, delivery_id) {
@@ -4144,6 +4129,10 @@ fn __occurred_at(event_kind, payload, raw) {
 
 fn __outbound_config(args) {
   let api_base_url = args?.api_base_url ?? harness.env.get_or("GITHUB_API_BASE_URL", GITHUB_API_BASE_URL)
+  let base_check = __validate_api_base_url(api_base_url)
+  if is_err(base_check) {
+    return base_check
+  }
   let direct_token = args?.installation_token ?? args?.token ?? args?.bindings?.installation_token
     ?? args?.secrets?.installation_token
     ?? harness.env.get("GITHUB_INSTALLATION_TOKEN")
@@ -4312,6 +4301,104 @@ fn __github_api_url(api_base_url, path) {
     return prefix + path
   }
   return prefix + "/" + path
+}
+
+@complexity(allow)
+fn __validate_api_base_url(api_base_url) {
+  if api_base_url == nil || trim(to_string(api_base_url)) == "" {
+    return __err("invalid_api_base_url", "api_base_url is required")
+  }
+  let url = trim(to_string(api_base_url))
+  if !starts_with(lowercase(url), "https://") {
+    return __err("invalid_api_base_url", "api_base_url must use https:// scheme")
+  }
+  let after_scheme = url[8:len(url)]
+  let slash_idx = __index_of(after_scheme, "/")
+  let host_port = if slash_idx >= 0 {
+    after_scheme[0:slash_idx]
+  } else {
+    after_scheme
+  }
+  let host = __strip_port(host_port)
+  if host == "" {
+    return __err("invalid_api_base_url", "api_base_url is missing a host")
+  }
+  let host_lc = lowercase(host)
+  if __is_disallowed_host(host_lc) {
+    return __err(
+      "invalid_api_base_url",
+      "api_base_url host `" + host
+        + "` is not allowed (loopback/private/link-local/.internal/.local are blocked)",
+    )
+  }
+  return Ok(true)
+}
+
+fn __strip_port(host_port) {
+  if starts_with(host_port, "[") {
+    let close = __index_of(host_port, "]")
+    if close >= 0 {
+      return host_port[1:close]
+    }
+    return host_port
+  }
+  let colon = __index_of(host_port, ":")
+  if colon >= 0 {
+    return host_port[0:colon]
+  }
+  return host_port
+}
+
+fn __index_of(text, needle) {
+  let n = len(text)
+  let m = len(needle)
+  if m == 0 {
+    return 0
+  }
+  var i = 0
+  while i + m <= n {
+    if text[i:i + m] == needle {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
+@complexity(allow)
+fn __is_disallowed_host(host_lc) {
+  if host_lc == "localhost" {
+    return true
+  }
+  if ends_with(host_lc, ".localhost") || ends_with(host_lc, ".local")
+    || ends_with(host_lc, ".internal") {
+    return true
+  }
+  if host_lc == "::1" || host_lc == "0:0:0:0:0:0:0:1" {
+    return true
+  }
+  if starts_with(host_lc, "127.") || starts_with(host_lc, "10.")
+    || starts_with(host_lc, "169.254.")
+    || starts_with(host_lc, "192.168.") {
+    return true
+  }
+  if starts_with(host_lc, "172.") {
+    let rest = host_lc[4:len(host_lc)]
+    let dot = __index_of(rest, ".")
+    if dot > 0 {
+      let octet_str = rest[0:dot]
+      let parsed = try {
+        to_int(octet_str)
+      }
+      if !is_err(parsed) {
+        let octet = unwrap(parsed)
+        if octet >= 16 && octet <= 31 {
+          return true
+        }
+      }
+    }
+  }
+  return false
 }
 
 fn __trim_leading_slash(path) {
@@ -4593,11 +4680,7 @@ fn __github_request_error(response) {
     return __err("network", response?.error?.message ?? to_string(response?.error ?? response))
   }
   let code = __github_error_code(response)
-  return __err(
-    code,
-    "github API request failed with status " + to_string(response.status) + ": "
-      + __github_error_message(response),
-  )
+  return __err(code, "github API request failed with status " + to_string(response.status))
 }
 
 fn __github_error_code(response) {
@@ -4678,6 +4761,10 @@ fn __maybe_wait_for_rate_limit(response, cfg) {
 
 fn __resolve_token_config(config) {
   let api_base_url = config?.api_base_url ?? GITHUB_API_BASE_URL
+  let base_check = __validate_api_base_url(api_base_url)
+  if is_err(base_check) {
+    return base_check
+  }
   let app_id = config?.app_id
   let installation_id = config?.installation_id
   if app_id == nil || installation_id == nil {
@@ -4764,8 +4851,7 @@ fn __exchange_installation_token(config) {
     }
     return __err(
       "installation_token_failed",
-      "failed to create GitHub installation token (" + to_string(response.status) + "): "
-        + to_string(response?.body ?? response?.error?.message ?? ""),
+      "failed to create GitHub installation token (status " + to_string(response.status) + ")",
     )
   }
   let payload = response.json

--- a/tests/dashboard_events.harn
+++ b/tests/dashboard_events.harn
@@ -1,4 +1,4 @@
-import { call } from "../src/lib"
+import { call, init, shutdown } from "../src/lib"
 import { fixture_raw, github_normalize } from "./helpers"
 
 fn find_intent(intents, name) {
@@ -12,6 +12,8 @@ fn find_intent(intents, name) {
 
 pipeline default() {
   let secret = "test-signing-secret"
+  shutdown()
+  init({signing_secret: secret})
   let issue = github_normalize(fixture_raw(harness, "issues_opened", secret, "issues"))
   let issue_payload = issue.event.payload
   assert_eq(issue_payload.source.kind, "github.issue", "issue primary source kind")

--- a/tests/helpers.harn
+++ b/tests/helpers.harn
@@ -17,15 +17,19 @@ pub fn github_headers(secret, body, event, delivery = "delivery-1") {
   }
 }
 
+/**
+ * Build a raw inbound envelope WITHOUT embedding the signing secret. Tests must seed the secret via `init({signing_secret: secret})` before calling normalize_inbound.
+ */
 pub fn signed_raw(secret, body, event, extra = nil) {
-  return extra ?? {}
-    + {signing_secret: secret, body_text: body, headers: github_headers(secret, body, event)}
+  return extra ?? {} + {body_text: body, headers: github_headers(secret, body, event)}
 }
 
+/** Read a fixture JSON body from the test fixtures directory. */
 pub fn fixture_body(harness: Harness, name) {
   return harness.fs.read_text(source_dir() + "/fixtures/webhooks/" + name + ".json")
 }
 
+/** Build a signed raw inbound envelope from a named fixture. */
 pub fn fixture_raw(harness: Harness, name, secret, event, extra = nil) {
   return signed_raw(secret, fixture_body(harness, name), event, extra)
 }

--- a/tests/normalize_events.harn
+++ b/tests/normalize_events.harn
@@ -1,8 +1,10 @@
-import { shutdown } from "../src/lib"
+import { init, shutdown } from "../src/lib"
 import { fixture_raw, github_normalize } from "./helpers"
 
 pipeline default() {
   let secret = "test-signing-secret"
+  shutdown()
+  init({signing_secret: secret})
   let cases = [
     ["pull_request_opened", "pull_request", "pull_request.opened"],
     ["push", "push", "push"],

--- a/tests/normalize_smoke.harn
+++ b/tests/normalize_smoke.harn
@@ -1,4 +1,4 @@
-import { shutdown } from "../src/lib"
+import { init, shutdown } from "../src/lib"
 import {
   assert_github_interface,
   fixture_body,
@@ -10,6 +10,7 @@ import {
 pipeline default() {
   let secret = "test-signing-secret"
   assert_github_interface()
+  init({signing_secret: secret})
   let pr = github_normalize(fixture_raw(harness, "pull_request_opened", secret, "pull_request"))
   assert_eq(pr.type, "event", "pull request envelope type")
   assert_eq(pr.event.kind, "pull_request", "pull request event kind")
@@ -99,16 +100,13 @@ pipeline default() {
     "release source url",
   )
   let body = fixture_body(harness, "issues_opened")
-  let tampered = github_normalize(
-    {signing_secret: secret, body_text: body + " ", headers: github_headers(secret, body, "issues")},
-  )
+  let tampered = github_normalize({body_text: body + " ", headers: github_headers(secret, body, "issues")})
   assert_eq(tampered.type, "reject", "tampered body rejects")
   assert_eq(tampered.reject.status, 401, "tampered body status")
-  let missing_signature = github_normalize({signing_secret: secret, body_text: body, headers: {"x-github-event": "issues"}})
+  let missing_signature = github_normalize({body_text: body, headers: {"x-github-event": "issues"}})
   assert_eq(missing_signature.type, "reject", "missing signature rejects")
-  let wrong_secret = github_normalize(
-    {signing_secret: "wrong-secret", body_text: body, headers: github_headers(secret, body, "issues")},
-  )
+  init({signing_secret: "different-configured-secret"})
+  let wrong_secret = github_normalize({body_text: body, headers: github_headers(secret, body, "issues")})
   assert_eq(wrong_secret.type, "reject", "wrong secret rejects")
   shutdown()
 }


### PR DESCRIPTION
## Summary
Implements high-severity webhook + outbound security findings from the cross-repo audit (2026-05-23 sweep).

## Findings addressed (this PR)
- F3 api_base_url scheme/host validation (all)
- F4 drop raw.* signing_secret resolution; secret store / state.ctx only (all)
- F7 truncate upstream error body echoes (github only)
- F8 1 MiB cap on inbound webhook body (all)
- F12 derive signature_status from verify result (github only)
- F13 require binding_id; remove single-binding fallback (all)

## Deferred to follow-up
F5 (token cache encryption), F10 (gh auth fallback gating), F14 (bump workflow), F15 (replay protection), F16 (token expiry parse).

## Test plan
- [x] harn connector test passes (package metadata, harn check, harn lint, harn fmt --check, connector contract, all fixture tests, install/import smoke, doc examples)
- [x] Contract fixtures migrated from inline `signing_secret` to `secret_ids` (resolved via secret_get); HMACs recomputed against the harness fixture secret
- [x] Test helpers no longer embed signing_secret in raw; pipelines seed via init({signing_secret: ...})

Source: /tmp/harn-security-sweep/findings/01-github-family-connectors.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)