### PR TITLE
ci: move release workflow to Node 24 actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ steps.release.outputs.tag }}
@@ -53,7 +53,7 @@ jobs:
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
       - name: Cache harn-cli
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
## Summary
- bump release workflow checkout from v4 to v6
- bump release workflow cache from v4 to v5
- remove the remaining Node 20 runtime drift from first-party GitHub actions in this repo

## Verification
- actionlint .github/workflows/*.yml
- rg -n 'uses:\s*actions/(checkout|cache)@v4\b' .github/workflows || true
- git diff --check