### PR TITLE
feat: Actions runners API, user-OAuth, @-mention extractor, async mergeable resolver (C1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+## 0.4.0 - 2026-06-02
+
+- Add GitHub Actions self-hosted runner management methods supporting both repo
+  (`owner`+`repo`) and org (`org`) scope: `actions.runners.registration_token`,
+  `remove_token`, `generate_jitconfig` (stateless single-use), `list`, `get`,
+  `delete`, `downloads`, `labels.list/add/replace/remove`, and
+  `actions.runner_groups.list/create/get/update/delete`. Mutating methods need
+  repo `administration:write` or org
+  `organization_self_hosted_runners:write`.
+- Add a CPU-only `@handle command args...` mention extractor to
+  `normalize_inbound`. Issue, PR, and comment payloads gain a `mention` block
+  (`{candidates, actor, command, handle, rest, issue_number?, comment_id?,
+  html_url?}`); the `github_extract_mentions(body)` helper exposes the parser.
+- Add user-to-server OAuth methods `oauth.user.device_code`,
+  `oauth.user.device_poll`, `oauth.user.exchange_code`, and
+  `oauth.user.refresh` (plus matching helpers) for "connect your GitHub
+  account". `ghu_`/`ghr_` tokens rotate on refresh. Adds the `oauth`
+  connector capability.
+- Add `pull_requests.resolve_mergeable` (and `github_resolve_mergeable`) to
+  resolve a PR's async `mergeable`/`mergeable_state` with bounded polling,
+  surfacing `is_conflict`.
+- Add `repos.commit_pulls` and `github_resolve_pr_for_sha(owner, repo, sha)`
+  to recover the PR for a commit SHA, preferring payload `pull_requests[]` and
+  falling back to the commit→pulls lookup for forks and `status` events.
 - Tighten repo-local agent guidance and README runtime notes.
 - Add latest-release and release-asset helpers for release automation.
 - Add `api_call` as a raw REST compatibility escape hatch.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ fields for Harn consumers:
 | `installation_id` | GitHub App installation id when present. |
 | `repository` / `repo` | Raw repository plus normalized `{owner, name, full_name}`. |
 | `source` / `source_refs` | Provider-neutral source refs with repo slugs, resource ids, and links. |
+| `mention` | `@handle command args...` directives parsed from issue/PR/comment bodies: `{candidates: [{handle, command, rest}], actor, command, handle, rest, issue_number?, comment_id?, html_url?}`. CPU-only; downstream filters `candidates` by bot identity. |
 | `triage_event` | `harn.triage_event.v1` envelope for issues, PRs, comments, and reviews. |
 | `job_event` | `harn.job_event.v1` envelope for checks, runs, releases, pushes, deployments, and merge queue events. |
 | `raw` | Original GitHub payload for fields not promoted by the connector. |
@@ -123,8 +124,10 @@ Call methods through `call(method, args)` unless a named helper fits better.
 
 | Area | Methods |
 |---|---|
-| Pull requests | `github.pr.list`, `github.pr.view`, `github.pr.checks`, `github.pr.merge`, `github.pr.enable_auto_merge`, `github.pr.comment`, `pulls.list`, `pulls.list_with_checks`, `pulls.get`, `pulls.merge`, `pulls.merge_safe`, `pulls.create_review_comment`, `pulls.get_diff`, `pulls.list_files`, `pulls.list_reviews` |
+| Pull requests | `github.pr.list`, `github.pr.view`, `github.pr.checks`, `github.pr.merge`, `github.pr.enable_auto_merge`, `github.pr.comment`, `pulls.list`, `pulls.list_with_checks`, `pulls.get`, `pulls.merge`, `pulls.merge_safe`, `pulls.create_review_comment`, `pulls.get_diff`, `pulls.list_files`, `pulls.list_reviews`, `pull_requests.resolve_mergeable`, `repos.commit_pulls` |
 | Actions and checks | `github.actions.workflow_dispatch`, `github.actions.runs`, `github.actions.run`, `github.actions.logs`, `actions.workflow_dispatch`, `actions.workflow_runs.list`, `actions.workflow_run.get`, `check_runs.create`, `check_runs.update` |
+| Self-hosted runners | `actions.runners.registration_token`, `actions.runners.remove_token`, `actions.runners.generate_jitconfig`, `actions.runners.list`, `actions.runners.get`, `actions.runners.delete`, `actions.runners.downloads`, `actions.runners.labels.list`, `actions.runners.labels.add`, `actions.runners.labels.replace`, `actions.runners.labels.remove`, `actions.runner_groups.list`, `actions.runner_groups.create`, `actions.runner_groups.get`, `actions.runner_groups.update`, `actions.runner_groups.delete` |
+| User OAuth | `oauth.user.device_code`, `oauth.user.device_poll`, `oauth.user.exchange_code`, `oauth.user.refresh` |
 | Issues | `github.issue.create`, `github.issue.comment`, `issues.create_comment`, `issues.create`, `issues.create_with_template`, `issues.update`, `issues.add_labels` |
 | Repository and release data | `github.release.latest`, `github.release.assets`, `github.branch.protection`, `repos.get_content`, `repos.get_text`, `repos.get_latest_release`, `repos.list_release_assets`, `repos.get_branch_protection`, `git.delete_ref` |
 | Merge queue | `github.merge_queue.entries`, `github.merge_queue.enqueue` |
@@ -152,6 +155,16 @@ Named helpers:
 | `github_wait_for_pr_checks(owner, repo, pull_number_or_ref, options)` | Wait for visible PR or commit checks; optionally attach failing Actions log tails. |
 | `github_find_open_pr(owner, repo, options)` | Find the first open PR matching `head_ref`, `base_ref`, `title`, or `labels`. |
 | `github_close_pr(owner, repo, pull_number, comment, options)` | Close a PR and optionally post a final comment. |
+| `github_resolve_mergeable(owner, repo, pull_number, options)` | Resolve a PR's async `mergeable`/`mergeable_state` with bounded polling; returns `{mergeable, mergeable_state, is_conflict, ...}`. |
+| `github_resolve_pr_for_sha(owner, repo, sha, options)` | Resolve the PR for a commit SHA, preferring payload `pull_requests[]` and falling back to `repos.commit_pulls`. |
+| `github_extract_mentions(body)` | Pure string parse of `@handle command args...` mentions in a body. |
+| `actions_runner_registration_token(scope, options)` | Create a self-hosted runner registration token (`scope` is `{org}` or `{owner, repo}`). |
+| `actions_runner_generate_jitconfig(scope, name, runner_group_id, labels, options)` | Generate a stateless single-use JIT runner config. |
+| `actions_runners_list(scope, options)` | List self-hosted runners for a repo or org scope. |
+| `oauth_user_device_code(client_id, scope, options)` | Begin the user OAuth device flow. |
+| `oauth_user_device_poll(client_id, device_code, options)` | Poll for the device-flow user token. |
+| `oauth_user_exchange_code(client_id, code, options)` | Exchange a web-flow code for a user token. |
+| `oauth_user_refresh(client_id, refresh_token, options)` | Refresh an expiring `ghu_` user token (rotates the `ghr_` refresh token). |
 
 Token helpers:
 
@@ -213,6 +226,8 @@ Required GitHub App permissions depend on the method:
 | Branch protection helpers | Administration read. |
 | Actions dispatch | Actions write. |
 | Actions run and log reads | Actions read. |
+| Self-hosted runner reads (list/get/labels.list/downloads) | Repo `administration:read` or org `organization_self_hosted_runners:read`. |
+| Self-hosted runner writes (registration/remove tokens, JIT config, delete, label add/replace/remove, runner groups) | Repo `administration:write` or org `organization_self_hosted_runners:write`. |
 | Check run create/update | Checks read/write. |
 | `api_call` and `graphql` | Whatever the endpoint, query, or mutation requires. |
 
@@ -231,7 +246,12 @@ explicit `gh_token`, `GH_TOKEN`, `GITHUB_TOKEN`, or `gh auth token`.
 - Webhook signing secrets may be supplied directly for local tests or resolved
   from the active Harn SecretProvider.
 - Outbound calls use GitHub App installation tokens or a caller-provided
-  installation token. OAuth user-token setup is out of scope.
+  installation token. The `oauth.user.*` methods add a separate
+  user-to-server flow (device and web-flow) for "connect your GitHub account";
+  they post to github.com, not the REST API host, and do not affect the App
+  flow that drives webhooks. `ghu_` user tokens last 8h and `ghr_` refresh
+  tokens 6 months; both rotate on refresh, so persist the returned
+  `refresh_token`.
 - Outbound HTTP dispatch uses Harn's shared connector policy layer for request
   envelopes, retries, rate-limit header extraction, and JSON parse categories.
 - GitHub primary rate-limit responses with short reset windows are retried

--- a/harn.toml
+++ b/harn.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harn-github-connector"
-version = "0.3.0"
+version = "0.4.0"
 description = "Pure-Harn GitHub App connector: webhooks, installation token rotation, REST/GraphQL dispatch."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn-github-connector"
@@ -12,7 +12,7 @@ default = "src/lib.harn"
 [[providers]]
 id = "github"
 connector = { harn = "src/lib.harn" }
-capabilities = ["webhook", "rate_limit", "pagination", "graphql"]
+capabilities = ["webhook", "rate_limit", "pagination", "graphql", "oauth"]
 
 [providers.setup]
 auth_type = "github-app"

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -54,8 +54,30 @@ let GITHUB_OUTBOUND_METHODS = [
   "actions.workflow_dispatch",
   "actions.workflow_runs.list",
   "actions.workflow_run.get",
+  "actions.runners.registration_token",
+  "actions.runners.remove_token",
+  "actions.runners.generate_jitconfig",
+  "actions.runners.list",
+  "actions.runners.get",
+  "actions.runners.delete",
+  "actions.runners.downloads",
+  "actions.runners.labels.list",
+  "actions.runners.labels.add",
+  "actions.runners.labels.replace",
+  "actions.runners.labels.remove",
+  "actions.runner_groups.list",
+  "actions.runner_groups.create",
+  "actions.runner_groups.get",
+  "actions.runner_groups.update",
+  "actions.runner_groups.delete",
   "check_runs.create",
   "check_runs.update",
+  "repos.commit_pulls",
+  "pull_requests.resolve_mergeable",
+  "oauth.user.device_code",
+  "oauth.user.device_poll",
+  "oauth.user.exchange_code",
+  "oauth.user.refresh",
   "graphql",
 ]
 
@@ -130,6 +152,7 @@ pub fn payload_schema() {
         source_refs: {type: ["array", "null"]},
         triage_event: {type: ["object", "null"]},
         job_event: {type: ["object", "null"]},
+        mention: {type: ["object", "null"]},
         raw: {type: "object"},
         issue: {type: ["object", "null"]},
         pull_request: {type: ["object", "null"]},
@@ -226,6 +249,9 @@ pub fn normalize_inbound(raw) {
 pub fn call(method, args = {}) {
   if !contains(GITHUB_OUTBOUND_METHODS, method) {
     return __err("method_not_found", "github connector does not implement outbound method `" + method + "`")
+  }
+  if starts_with(method, "oauth.user.") {
+    return __oauth_user_dispatch(method, args ?? {})
   }
   let config = __outbound_config(args ?? {})
   if is_err(config) {
@@ -483,6 +509,15 @@ pub fn call(method, args = {}) {
   if method == "actions.workflow_run.get" {
     return __actions_workflow_run_get(args, cfg)
   }
+  if starts_with(method, "actions.runners.") || starts_with(method, "actions.runner_groups.") {
+    return __actions_runners_dispatch(method, args, cfg)
+  }
+  if method == "repos.commit_pulls" {
+    return __repos_commit_pulls(args, cfg)
+  }
+  if method == "pull_requests.resolve_mergeable" {
+    return __pull_requests_resolve_mergeable(args, cfg)
+  }
   if method == "check_runs.create" {
     return __github_json(
       "POST",
@@ -551,10 +586,95 @@ pub fn actions_workflow_runs(owner, repo, options = nil) {
   return call("actions.workflow_runs.list", opts + {owner: owner, repo: repo})
 }
 
+/**
+ * Create a self-hosted runner registration token. Pass `org` for org scope, or
+ * `owner`+`repo` for repo scope (via `scope`). Requires `administration:write`
+ * (repo) or `organization_self_hosted_runners:write` (org).
+ */
+pub fn actions_runner_registration_token(scope, options = nil) {
+  let opts = options ?? {}
+  return call("actions.runners.registration_token", opts + scope ?? {})
+}
+
+/**
+ * Generate an ephemeral just-in-time runner config (the modern stateless,
+ * single-use registration path). `scope` is `{org}` or `{owner, repo}`; the
+ * body carries `{name, runner_group_id, labels[], work_folder?}`. Requires
+ * `administration:write` (repo) or `organization_self_hosted_runners:write` (org).
+ */
+pub fn actions_runner_generate_jitconfig(
+  scope,
+  name,
+  runner_group_id = 1,
+  labels = [],
+  options = nil,
+) {
+  let opts = options ?? {}
+  return call(
+    "actions.runners.generate_jitconfig",
+    opts + scope ?? {} + {name: name, runner_group_id: runner_group_id, labels: labels},
+  )
+}
+
+/** List self-hosted runners for a repo (`{owner, repo}`) or org (`{org}`) scope. */
+pub fn actions_runners_list(scope, options = nil) {
+  let opts = options ?? {}
+  return call("actions.runners.list", opts + scope ?? {})
+}
+
 /** Dispatch one raw GitHub REST call. Prefer typed helpers when one exists. */
 pub fn api_call(path, method = "GET", body = nil, options = nil) {
   let opts = options ?? {}
   return call("api_call", opts + {path: path, method: method, body: body})
+}
+
+/**
+ * Begin the user-to-server OAuth device flow. Returns GitHub's
+ * `{device_code, user_code, verification_uri, expires_in, interval}` payload.
+ * `ghu_` user tokens expire after 8h and `ghr_` refresh tokens after 6 months.
+ */
+pub fn oauth_user_device_code(client_id, scope = nil, options = nil) {
+  let opts = options ?? {}
+  var args = opts + {client_id: client_id}
+  if scope != nil {
+    args["scope"] = scope
+  }
+  return call("oauth.user.device_code", args)
+}
+
+/**
+ * Poll the device-flow token endpoint. Returns the granted token payload, or a
+ * payload with `error` (e.g. `authorization_pending`, `slow_down`) while the
+ * user has not yet authorized.
+ */
+pub fn oauth_user_device_poll(client_id, device_code, options = nil) {
+  let opts = options ?? {}
+  return call("oauth.user.device_poll", opts + {client_id: client_id, device_code: device_code})
+}
+
+/** Exchange a web-flow authorization `code` for a user access token. */
+pub fn oauth_user_exchange_code(client_id, code, options = nil) {
+  let opts = options ?? {}
+  return call("oauth.user.exchange_code", opts + {client_id: client_id, code: code})
+}
+
+/**
+ * Refresh an expiring `ghu_` user token. The `ghr_` refresh token ROTATES on
+ * every refresh, so callers must persist the returned `refresh_token`.
+ */
+pub fn oauth_user_refresh(client_id, refresh_token, options = nil) {
+  let opts = options ?? {}
+  return call("oauth.user.refresh", opts + {client_id: client_id, refresh_token: refresh_token})
+}
+
+/**
+ * Extract `@handle command args...` mentions from a free-text body using pure
+ * string scanning (CPU-only, no network). Returns a list of
+ * `{handle, command, rest}` candidates. Mirrors the `mention.candidates`
+ * surfaced on normalized issue/PR/comment payloads.
+ */
+pub fn github_extract_mentions(body) {
+  return __extract_mention_candidates(body)
 }
 
 /** Read a repository file as decoded UTF-8 text at an optional ref. */
@@ -2051,6 +2171,396 @@ fn __actions_workflow_run_get(args, cfg) {
   )
 }
 
+/**
+ * Resolve the REST path prefix for self-hosted-runner methods that accept
+ * either a repo scope (`owner` + `repo`) or an org scope (`org`). Returns
+ * `Ok("/repos/{owner}/{repo}")` or `Ok("/orgs/{org}")`, or a schema_drift error
+ * when neither scope is supplied.
+ */
+fn __runner_scope_prefix(args) {
+  let org = args?.org
+  if org != nil && trim(to_string(org)) != "" {
+    return Ok("/orgs/" + url_encode(to_string(org)))
+  }
+  if args?.owner != nil && trim(to_string(args.owner)) != "" && args?.repo != nil
+    && trim(to_string(args.repo)) != "" {
+    return Ok("/repos/" + to_string(args.owner) + "/" + to_string(args.repo))
+  }
+  return __err("schema_drift", "self-hosted runner methods require `org`, or `owner` + `repo`")
+}
+
+/**
+ * Dispatch GitHub Actions self-hosted runner and runner-group methods.
+ * Mutating methods (registration_token, remove_token, generate_jitconfig,
+ * delete, labels add/replace/remove, runner_groups create/update/delete)
+ * require the `administration:write` repo permission or the
+ * `organization_self_hosted_runners:write` org permission. Read methods
+ * require the matching read permission.
+ */
+@complexity(allow)
+fn __actions_runners_dispatch(method, args, cfg) {
+  let runner_id = args?.runner_id ?? args?.id
+  if method == "actions.runner_groups.list" || method == "actions.runner_groups.create" {
+    let org = args?.org
+    if org == nil || trim(to_string(org)) == "" {
+      return __err("schema_drift", method + " requires `org`")
+    }
+    let url = __github_api_url(cfg.api_base_url, "/orgs/" + url_encode(to_string(org)) + "/actions/runner-groups")
+    if method == "actions.runner_groups.create" {
+      return __github_json("POST", url, __body_without(args, __config_keys() + ["org"]), cfg)
+    }
+    return __github_json("GET", url + __pagination_query(args), nil, cfg)
+  }
+  if method == "actions.runner_groups.get" || method == "actions.runner_groups.update"
+    || method == "actions.runner_groups.delete" {
+    let org = args?.org
+    let group_id = args?.runner_group_id ?? args?.group_id ?? args?.id
+    if org == nil || trim(to_string(org)) == "" || group_id == nil {
+      return __err("schema_drift", method + " requires `org` and `runner_group_id`")
+    }
+    let url = __github_api_url(
+      cfg.api_base_url,
+      "/orgs/" + url_encode(to_string(org)) + "/actions/runner-groups/" + to_string(group_id),
+    )
+    if method == "actions.runner_groups.update" {
+      return __github_json(
+        "PATCH",
+        url,
+        __body_without(args, __config_keys() + ["org", "runner_group_id", "group_id", "id"]),
+        cfg,
+      )
+    }
+    if method == "actions.runner_groups.delete" {
+      return __github_json("DELETE", url, nil, cfg)
+    }
+    return __github_json("GET", url, nil, cfg)
+  }
+  let prefix = __runner_scope_prefix(args)
+  if is_err(prefix) {
+    return prefix
+  }
+  let base = unwrap(prefix) + "/actions/runners"
+  if method == "actions.runners.registration_token" {
+    return __github_json("POST", __github_api_url(cfg.api_base_url, base + "/registration-token"), nil, cfg)
+  }
+  if method == "actions.runners.remove_token" {
+    return __github_json("POST", __github_api_url(cfg.api_base_url, base + "/remove-token"), nil, cfg)
+  }
+  if method == "actions.runners.generate_jitconfig" {
+    return __github_json(
+      "POST",
+      __github_api_url(cfg.api_base_url, base + "/generate-jitconfig"),
+      __runner_jitconfig_body(args),
+      cfg,
+    )
+  }
+  if method == "actions.runners.downloads" {
+    return __github_json("GET", __github_api_url(cfg.api_base_url, base + "/downloads"), nil, cfg)
+  }
+  if method == "actions.runners.list" {
+    return __github_json("GET", __github_api_url(cfg.api_base_url, base + __pagination_query(args)), nil, cfg)
+  }
+  if method == "actions.runners.get" || method == "actions.runners.delete" {
+    if runner_id == nil {
+      return __err("schema_drift", method + " requires `runner_id`")
+    }
+    let url = __github_api_url(cfg.api_base_url, base + "/" + to_string(runner_id))
+    if method == "actions.runners.delete" {
+      return __github_json("DELETE", url, nil, cfg)
+    }
+    return __github_json("GET", url, nil, cfg)
+  }
+  if starts_with(method, "actions.runners.labels.") {
+    if runner_id == nil {
+      return __err("schema_drift", method + " requires `runner_id`")
+    }
+    let url = __github_api_url(cfg.api_base_url, base + "/" + to_string(runner_id) + "/labels")
+    if method == "actions.runners.labels.list" {
+      return __github_json("GET", url, nil, cfg)
+    }
+    if method == "actions.runners.labels.add" {
+      return __github_json("POST", url, {labels: args?.labels ?? []}, cfg)
+    }
+    if method == "actions.runners.labels.replace" {
+      return __github_json("PUT", url, {labels: args?.labels ?? []}, cfg)
+    }
+    if method == "actions.runners.labels.remove" {
+      let label = args?.name ?? args?.label
+      if label != nil && trim(to_string(label)) != "" {
+        return __github_json("DELETE", url + "/" + url_encode(to_string(label)), nil, cfg)
+      }
+      return __github_json("DELETE", url, nil, cfg)
+    }
+  }
+  return __err("method_not_found", "unsupported runner method `" + method + "`")
+}
+
+fn __runner_jitconfig_body(args) {
+  let name = args?.name
+  if name == nil || trim(to_string(name)) == "" {
+    return {error: "missing_name"}
+  }
+  var body = {name: to_string(name), runner_group_id: args?.runner_group_id ?? 1, labels: args?.labels ?? []}
+  if args?.work_folder != nil {
+    body["work_folder"] = args.work_folder
+  }
+  return body
+}
+
+/**
+ * GET /repos/{owner}/{repo}/commits/{sha}/pulls — list pull requests that
+ * contain the given commit. Used to recover the PR for `status` events and
+ * fork pushes whose webhook `pull_requests[]` array is empty.
+ */
+fn __repos_commit_pulls(args, cfg) {
+  let repo = __repo_parts(args)
+  if is_err(repo) {
+    return repo
+  }
+  let r = unwrap(repo)
+  let sha = args?.sha ?? args?.commit_sha
+  if sha == nil || trim(to_string(sha)) == "" {
+    return __err("schema_drift", "repos.commit_pulls requires `sha`")
+  }
+  return __github_json(
+    "GET",
+    __github_api_url(
+      cfg.api_base_url,
+      "/repos/" + r.owner + "/" + r.name + "/commits/" + url_encode(to_string(sha)) + "/pulls"
+        + __pagination_query(args),
+    ),
+    nil,
+    cfg,
+  )
+}
+
+let DEFAULT_MERGEABLE_MAX_ATTEMPTS = 4
+
+let DEFAULT_MERGEABLE_POLL_INTERVAL_MS = 1500
+
+/**
+ * Resolve a PR's async-computed `mergeable`/`mergeable_state` by GETting the
+ * single-PR endpoint (which triggers the background computation) and polling
+ * with bounded backoff while `mergeable` is null or `mergeable_state` is
+ * "unknown". Returns `{ok, mergeable, mergeable_state, is_conflict, attempts,
+ * resolved, raw, error}`. The poll bound is `max_attempts` (default 4) with
+ * `poll_interval_ms` (default 1500ms) between attempts.
+ */
+@complexity(allow)
+fn __pull_requests_resolve_mergeable(args, cfg) {
+  let repo = __repo_parts(args)
+  if is_err(repo) {
+    return __mergeable_envelope(false, nil, "unknown", 0, false, nil, unwrap_err(repo))
+  }
+  let r = unwrap(repo)
+  let number = args?.pull_number ?? args?.number ?? args?.pr_number
+  if number == nil {
+    return __mergeable_envelope(
+      false,
+      nil,
+      "unknown",
+      0,
+      false,
+      nil,
+      {code: "schema_drift", category: "schema_drift", message: "resolve_mergeable requires pull_number"},
+    )
+  }
+  let max_attempts = max(1, __positive_int(args?.max_attempts, DEFAULT_MERGEABLE_MAX_ATTEMPTS))
+  let poll_interval = __positive_int(args?.poll_interval_ms, DEFAULT_MERGEABLE_POLL_INTERVAL_MS)
+  let url = __github_api_url(
+    cfg.api_base_url,
+    "/repos/" + r.owner + "/" + r.name + "/pulls/" + to_string(number),
+  )
+  var attempt = 0
+  var last = nil
+  while attempt < max_attempts {
+    attempt = attempt + 1
+    let pull = __github_json("GET", url, nil, cfg)
+    if is_err(pull) {
+      return __mergeable_envelope(false, nil, "unknown", attempt, false, nil, unwrap_err(pull))
+    }
+    last = pull
+    let mergeable = pull?.mergeable
+    let state = pull?.mergeable_state ?? "unknown"
+    if mergeable != nil && state != "unknown" {
+      return __mergeable_envelope(true, mergeable, state, attempt, true, pull, nil)
+    }
+    if attempt < max_attempts && poll_interval > 0 {
+      sleep(poll_interval)
+    }
+  }
+  return __mergeable_envelope(
+    true,
+    last?.mergeable,
+    last?.mergeable_state ?? "unknown",
+    attempt,
+    false,
+    last,
+    nil,
+  )
+}
+
+fn __mergeable_envelope(ok, mergeable, mergeable_state, attempts, resolved, raw, error) {
+  return {
+    ok: ok,
+    mergeable: mergeable,
+    mergeable_state: mergeable_state,
+    is_conflict: mergeable_state == "dirty",
+    attempts: attempts,
+    resolved: resolved,
+    raw: raw,
+    error: error,
+  }
+}
+
+/**
+ * Resolve the first PR number for a commit SHA. Prefers the webhook payload's
+ * `pull_requests[]` array (present on PR-scoped events), falling back to the
+ * `repos.commit_pulls` REST lookup for forks and `status` events that carry no
+ * PR. Returns `{ok, found, pull_number, pull_request, source, error}` where
+ * `source` is `payload` or `commit_pulls`.
+ */
+pub fn github_resolve_pr_for_sha(owner, repo, sha, options = nil) {
+  let opts = options ?? {}
+  let payload_prs = opts?.pull_requests ?? []
+  let from_payload = __first(payload_prs)
+  if from_payload != nil && from_payload?.number != nil {
+    return {
+      ok: true,
+      found: true,
+      pull_number: from_payload.number,
+      pull_request: from_payload,
+      source: "payload",
+      error: nil,
+    }
+  }
+  let auth = __auth_options(opts)
+  let pulls = call("repos.commit_pulls", auth + {owner: owner, repo: repo, sha: sha})
+  if is_err(pulls) {
+    return {
+      ok: false,
+      found: false,
+      pull_number: nil,
+      pull_request: nil,
+      source: "commit_pulls",
+      error: unwrap_err(pulls),
+    }
+  }
+  let first = __first(pulls)
+  if first == nil || first?.number == nil {
+    return {ok: true, found: false, pull_number: nil, pull_request: nil, source: "commit_pulls", error: nil}
+  }
+  return {
+    ok: true,
+    found: true,
+    pull_number: first.number,
+    pull_request: first,
+    source: "commit_pulls",
+    error: nil,
+  }
+}
+
+/**
+ * Resolve a PR's async mergeable state via the connector `call` surface.
+ * Returns the `{mergeable, mergeable_state, is_conflict, ...}` envelope from
+ * `pull_requests.resolve_mergeable`.
+ */
+pub fn github_resolve_mergeable(owner, repo, pull_number, options = nil) {
+  let opts = options ?? {}
+  return call("pull_requests.resolve_mergeable", opts + {owner: owner, repo: repo, pull_number: pull_number})
+}
+
+let GITHUB_OAUTH_BASE_URL = "https://github.com"
+
+/**
+ * Dispatch user-to-server OAuth methods. These connect an end user's GitHub
+ * account (distinct from the GitHub App installation flow that drives
+ * webhooks) and post to github.com, not the REST API host. `ghu_` user tokens
+ * expire after 8h and `ghr_` refresh tokens after 6 months; both ROTATE on
+ * refresh, so callers must persist the returned `refresh_token`.
+ */
+@complexity(allow)
+fn __oauth_user_dispatch(method, args) {
+  let client_id = args?.client_id ?? harness.env.get("GITHUB_OAUTH_CLIENT_ID")
+  if client_id == nil || trim(to_string(client_id)) == "" {
+    return __err("schema_drift", method + " requires `client_id`")
+  }
+  let base = args?.oauth_base_url ?? GITHUB_OAUTH_BASE_URL
+  if method == "oauth.user.device_code" {
+    var body = {client_id: to_string(client_id)}
+    if args?.scope != nil {
+      body["scope"] = to_string(args.scope)
+    }
+    return __oauth_post(args?.device_code_url ?? base + "/login/device/code", body, args)
+  }
+  if method == "oauth.user.device_poll" {
+    let device_code = args?.device_code
+    if device_code == nil || trim(to_string(device_code)) == "" {
+      return __err("schema_drift", "oauth.user.device_poll requires `device_code`")
+    }
+    return __oauth_post(
+      args?.access_token_url ?? base + "/login/oauth/access_token",
+      {
+        client_id: to_string(client_id),
+        device_code: to_string(device_code),
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      },
+      args,
+    )
+  }
+  if method == "oauth.user.exchange_code" {
+    let code = args?.code
+    if code == nil || trim(to_string(code)) == "" {
+      return __err("schema_drift", "oauth.user.exchange_code requires `code`")
+    }
+    var body = {client_id: to_string(client_id), code: to_string(code)}
+    if args?.client_secret != nil {
+      body["client_secret"] = to_string(args.client_secret)
+    }
+    if args?.redirect_uri != nil {
+      body["redirect_uri"] = to_string(args.redirect_uri)
+    }
+    return __oauth_post(args?.access_token_url ?? base + "/login/oauth/access_token", body, args)
+  }
+  if method == "oauth.user.refresh" {
+    let refresh_token = args?.refresh_token
+    if refresh_token == nil || trim(to_string(refresh_token)) == "" {
+      return __err("schema_drift", "oauth.user.refresh requires `refresh_token`")
+    }
+    var body = {
+      client_id: to_string(client_id),
+      grant_type: "refresh_token",
+      refresh_token: to_string(refresh_token),
+    }
+    if args?.client_secret != nil {
+      body["client_secret"] = to_string(args.client_secret)
+    }
+    return __oauth_post(args?.access_token_url ?? base + "/login/oauth/access_token", body, args)
+  }
+  return __err("method_not_found", "unsupported oauth method `" + method + "`")
+}
+
+fn __oauth_post(url, body, args) {
+  let response = connector_http_json(
+    "POST",
+    url,
+    {
+      provider: "github",
+      operation: "oauth_user",
+      headers: {Accept: "application/json", "Content-Type": "application/json", "User-Agent": GITHUB_USER_AGENT},
+      body: json_stringify(body),
+      timeout_ms: args?.timeout_ms ?? 30000,
+    },
+  )
+  if !(response.ok ?? false) {
+    if response?.status == nil || to_int(response?.status ?? 0) == 0 {
+      return __err("network", response?.error?.message ?? to_string(response?.error ?? response))
+    }
+    return __err("oauth_failed", "github OAuth request failed with status " + to_string(response.status))
+  }
+  return response.json
+}
+
 fn __render_template(template, vars) {
   var rendered = to_string(template ?? "")
   for entry in (vars ?? {}).entries() {
@@ -2620,6 +3130,9 @@ fn __error_category(code) {
   if code == "network" || code == "transport" {
     return "network"
   }
+  if code == "oauth_failed" {
+    return "auth"
+  }
   if code == "schema_drift" || code == "invalid_response" || code == "invalid_json" {
     return "schema_drift"
   }
@@ -3073,11 +3586,127 @@ fn __normalize_github_payload(event_kind, raw, delivery_id, dedupe_key, occurred
   return __decorate_dashboard_payload(event_kind, common, dedupe_key, occurred_at)
 }
 
+let MENTION_HANDLE_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_/"
+
+/**
+ * Extract `@handle command args...` mentions from a free-text body using
+ * pure string scanning (no network, no regex). Returns a list of
+ * `{handle, command, rest}` candidates. A mention is recognized when `@` is at
+ * the start of the body or follows whitespace, the handle is a run of
+ * `[A-Za-z0-9-_/]`, and (optionally) a command word follows on the same line.
+ */
+@complexity(allow)
+fn __extract_mention_candidates(body) {
+  let text = to_string(body ?? "")
+  let n = len(text)
+  var out = []
+  var i = 0
+  while i < n {
+    let ch = text[i:i + 1]
+    let prev_is_boundary = i == 0 || __is_mention_boundary(text[i - 1:i])
+    if ch == "@" && prev_is_boundary {
+      var j = i + 1
+      while j < n && contains(MENTION_HANDLE_CHARS, text[j:j + 1]) {
+        j = j + 1
+      }
+      let handle = text[i + 1:j]
+      if handle != "" {
+        out = out + [__mention_from(handle, text, j, n)]
+      }
+      i = j
+    } else {
+      i = i + 1
+    }
+  }
+  return out
+}
+
+fn __is_mention_boundary(ch) {
+  return ch == " " || ch == "\n" || ch == "\t" || ch == "\r" || ch == "(" || ch == "["
+}
+
+fn __mention_from(handle, text, after_handle, n) {
+  // A command must be separated from the handle by whitespace; punctuation
+  // directly attached to the handle (e.g. `@reviewer!`) yields no command.
+  if after_handle < n {
+    let next = text[after_handle:after_handle + 1]
+    if next != " " && next != "\t" && next != "\n" && next != "\r" {
+      return {handle: handle, command: nil, rest: ""}
+    }
+  }
+  // Skip spaces/tabs (but not newlines) to find the command on the same line.
+  var k = after_handle
+  while k < n && (text[k:k + 1] == " " || text[k:k + 1] == "\t") {
+    k = k + 1
+  }
+  // Stop the command/rest scan at a newline.
+  var line_end = k
+  while line_end < n && text[line_end:line_end + 1] != "\n" {
+    line_end = line_end + 1
+  }
+  let rest_line = trim(text[k:line_end])
+  if rest_line == "" {
+    return {handle: handle, command: nil, rest: ""}
+  }
+  let space = __index_of(rest_line, " ")
+  if space < 0 {
+    return {handle: handle, command: rest_line, rest: ""}
+  }
+  return {handle: handle, command: rest_line[0:space], rest: trim(rest_line[space:len(rest_line)])}
+}
+
+/**
+ * Build the `mention` triage sub-block for events whose body may contain
+ * `@handle command` directives. Surfaces ALL @mentions as `candidates`
+ * (downstream filters by bot identity) plus the first command for convenience.
+ * Returns nil when the event kind has no body or no mentions are found.
+ */
+fn __mention_block(event_kind, payload) {
+  let body = __mention_body(event_kind, payload)
+  if body == nil || trim(to_string(body)) == "" {
+    return nil
+  }
+  let candidates = __extract_mention_candidates(body)
+  if len(candidates) == 0 {
+    return nil
+  }
+  let first = __first(candidates)
+  let actor = payload?.sender?.login ?? payload?.comment?.user?.login ?? payload?.issue?.user?.login
+    ?? payload?.pull_request?.user?.login
+  return {
+    candidates: candidates,
+    actor: actor,
+    command: first?.command,
+    handle: first?.handle,
+    rest: first?.rest,
+    issue_number: payload?.issue?.number ?? payload?.pull_request?.number ?? payload?.number,
+    comment_id: payload?.comment?.id,
+    html_url: payload?.comment?.html_url ?? payload?.issue?.html_url ?? payload?.pull_request?.html_url,
+  }
+}
+
+fn __mention_body(event_kind, payload) {
+  if event_kind == "issue_comment" || event_kind == "pull_request_review_comment" {
+    return payload?.comment?.body
+  }
+  if event_kind == "issues" {
+    return payload?.issue?.body
+  }
+  if event_kind == "pull_request" {
+    return payload?.pull_request?.body
+  }
+  return nil
+}
+
 @complexity(allow)
 fn __decorate_dashboard_payload(event_kind, payload, dedupe_key, occurred_at) {
   let source_refs = __source_refs(event_kind, payload)
   let source = __first(source_refs)
   var out = payload + {source: source, source_refs: source_refs}
+  let mention = __mention_block(event_kind, payload)
+  if mention != nil {
+    out["mention"] = mention
+  }
   let triage = __triage_event(event_kind, out, source, source_refs, dedupe_key, occurred_at)
   if triage != nil {
     out["triage_event"] = triage

--- a/tests/fixtures/webhooks/issue_comment_mention.json
+++ b/tests/fixtures/webhooks/issue_comment_mention.json
@@ -1,0 +1,27 @@
+{
+  "action": "created",
+  "issue": {
+    "number": 7,
+    "title": "Connector fixture issue",
+    "state": "open",
+    "html_url": "https://github.com/octo-org/octo-repo/issues/7",
+    "created_at": "2026-04-20T14:00:00Z",
+    "updated_at": "2026-04-20T15:00:00Z",
+    "user": {"id": 1001, "login": "octocat", "type": "User"}
+  },
+  "comment": {
+    "id": 9001,
+    "body": "Hey @harn-bot deploy staging now, and thanks @reviewer for the review!",
+    "html_url": "https://github.com/octo-org/octo-repo/issues/7#issuecomment-9001",
+    "created_at": "2026-04-20T15:00:00Z",
+    "updated_at": "2026-04-20T15:00:00Z",
+    "user": {"id": 1002, "login": "requester", "type": "User"}
+  },
+  "repository": {
+    "name": "octo-repo",
+    "full_name": "octo-org/octo-repo",
+    "owner": {"id": 2001, "login": "octo-org", "type": "Organization"}
+  },
+  "sender": {"id": 1002, "login": "requester", "type": "User"},
+  "installation": {"id": 3001}
+}

--- a/tests/mention_extraction.harn
+++ b/tests/mention_extraction.harn
@@ -1,0 +1,47 @@
+import { github_extract_mentions, init, shutdown } from "../src/lib"
+import { fixture_raw, github_normalize } from "./helpers"
+
+pipeline default() {
+  // 1. Pure helper: multiple mentions, command + args parsing.
+  let mentions = github_extract_mentions("Hey @harn-bot deploy staging now, and thanks @reviewer!")
+  assert_eq(len(mentions), 2, "two mention candidates")
+  assert_eq(mentions[0].handle, "harn-bot", "first handle")
+  assert_eq(mentions[0].command, "deploy", "first command")
+  assert_eq(mentions[0].rest, "staging now, and thanks @reviewer!", "first rest")
+  assert_eq(mentions[1].handle, "reviewer", "second handle")
+  assert_eq(mentions[1].command, nil, "trailing-punctuation mention has no command")
+  // 2. Boundary cases: email-like @ inside a word is not a mention boundary.
+  let no_mentions = github_extract_mentions("contact me at user@example.com please")
+  assert_eq(len(no_mentions), 0, "in-word @ is not a mention")
+  // 3. Mention at start of body, command with no args.
+  let start = github_extract_mentions("@deploybot run")
+  assert_eq(start[0].handle, "deploybot", "start handle")
+  assert_eq(start[0].command, "run", "start command")
+  assert_eq(start[0].rest, "", "start no rest")
+  // 4. Bare mention with no command.
+  let bare = github_extract_mentions("thanks @octocat")
+  assert_eq(bare[0].handle, "octocat", "bare handle")
+  assert_eq(bare[0].command, nil, "bare no command")
+  // 5. Command stops at newline (does not bleed across lines).
+  let multiline = github_extract_mentions("@bot deploy\nignored second line")
+  assert_eq(multiline[0].command, "deploy", "command stops at newline")
+  assert_eq(multiline[0].rest, "", "rest empty across newline")
+  // 6. End-to-end: normalize an issue_comment webhook and read mention block.
+  let secret = "test-signing-secret"
+  shutdown()
+  init({signing_secret: secret})
+  let normalized = github_normalize(fixture_raw(harness, "issue_comment_mention", secret, "issue_comment"))
+  assert_eq(normalized.type, "event", "mention event normalizes")
+  let mention = normalized.event.payload.mention
+  assert(mention != nil, "mention block present")
+  assert_eq(len(mention.candidates), 2, "two candidates in normalized payload")
+  assert_eq(mention.handle, "harn-bot", "first handle surfaced")
+  assert_eq(mention.command, "deploy", "first command surfaced")
+  assert_eq(mention.actor, "requester", "actor is comment author")
+  assert_eq(mention.issue_number, 7, "issue number surfaced")
+  assert_eq(mention.comment_id, 9001, "comment id surfaced")
+  // 7. A comment with no mentions has no mention block.
+  let plain = github_normalize(fixture_raw(harness, "issue_comment_created", secret, "issue_comment"))
+  assert_eq(plain.event.payload.mention, nil, "plain comment has no mention block")
+  shutdown()
+}

--- a/tests/mergeable_and_commit_pulls.harn
+++ b/tests/mergeable_and_commit_pulls.harn
@@ -1,0 +1,101 @@
+import { call, github_resolve_mergeable, github_resolve_pr_for_sha } from "../src/lib"
+
+pipeline default() {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  let base = "https://github-api.test"
+  let token = "github-installation-token"
+  let auth = {api_base_url: base, installation_token: token}
+  // resolve_mergeable: first GET returns null/unknown, second resolves clean.
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/pulls/42",
+    {
+      responses: [
+        {
+          status: 200,
+          body: "{\"number\":42,\"mergeable\":null,\"mergeable_state\":\"unknown\"}",
+          headers: {"x-ratelimit-remaining": "10"},
+        },
+        {
+          status: 200,
+          body: "{\"number\":42,\"mergeable\":true,\"mergeable_state\":\"clean\"}",
+          headers: {"x-ratelimit-remaining": "9"},
+        },
+      ],
+    },
+  )
+  let resolved = github_resolve_mergeable("octo-org", "octo-repo", 42, auth + {poll_interval_ms: 0, max_attempts: 4})
+  assert_eq(resolved.mergeable, true, "mergeable resolved true")
+  assert_eq(resolved.mergeable_state, "clean", "mergeable_state clean")
+  assert_eq(resolved.is_conflict, false, "clean is not a conflict")
+  assert_eq(resolved.resolved, true, "resolved within attempts")
+  assert_eq(resolved.attempts, 2, "took two attempts")
+  // resolve_mergeable: dirty == conflict.
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/pulls/99",
+    {
+      status: 200,
+      body: "{\"number\":99,\"mergeable\":false,\"mergeable_state\":\"dirty\"}",
+      headers: {"x-ratelimit-remaining": "8"},
+    },
+  )
+  let conflict = github_resolve_mergeable("octo-org", "octo-repo", 99, auth + {poll_interval_ms: 0})
+  assert_eq(conflict.is_conflict, true, "dirty is a conflict")
+  assert_eq(conflict.mergeable_state, "dirty", "dirty state")
+  // resolve_mergeable: stays unknown across all attempts -> ok but unresolved.
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/pulls/7",
+    {
+      status: 200,
+      body: "{\"number\":7,\"mergeable\":null,\"mergeable_state\":\"unknown\"}",
+      headers: {"x-ratelimit-remaining": "7"},
+    },
+  )
+  let stuck = github_resolve_mergeable("octo-org", "octo-repo", 7, auth + {poll_interval_ms: 0, max_attempts: 2})
+  assert_eq(stuck.resolved, false, "unresolved after max attempts")
+  assert_eq(stuck.mergeable_state, "unknown", "still unknown")
+  assert_eq(stuck.attempts, 2, "exhausted attempts")
+  // commit_pulls: direct REST lookup.
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/commits/abcdef1/pulls",
+    {
+      status: 200,
+      body: "[{\"number\":13,\"title\":\"From commit\"}]",
+      headers: {"x-ratelimit-remaining": "6"},
+    },
+  )
+  let pulls = call("repos.commit_pulls", auth + {owner: "octo-org", repo: "octo-repo", sha: "abcdef1"})
+  assert_eq(pulls[0].number, 13, "commit_pulls returns PR")
+  // github_resolve_pr_for_sha: prefers payload pull_requests[].
+  let from_payload = github_resolve_pr_for_sha(
+    "octo-org",
+    "octo-repo",
+    "abcdef1",
+    auth + {pull_requests: [{number: 55}]},
+  )
+  assert_eq(from_payload.source, "payload", "prefers payload PRs")
+  assert_eq(from_payload.pull_number, 55, "payload PR number")
+  // github_resolve_pr_for_sha: empty payload (fork) falls back to commit_pulls.
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/commits/deadbeef/pulls",
+    {status: 200, body: "[{\"number\":21}]", headers: {"x-ratelimit-remaining": "5"}},
+  )
+  let fallback = github_resolve_pr_for_sha("octo-org", "octo-repo", "deadbeef", auth + {pull_requests: []})
+  assert_eq(fallback.source, "commit_pulls", "falls back to commit_pulls")
+  assert_eq(fallback.pull_number, 21, "fallback PR number")
+  // github_resolve_pr_for_sha: status event with no PR anywhere -> not found.
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/commits/orphan/pulls",
+    {status: 200, body: "[]", headers: {"x-ratelimit-remaining": "4"}},
+  )
+  let none = github_resolve_pr_for_sha("octo-org", "octo-repo", "orphan", auth)
+  assert_eq(none.found, false, "no PR found for orphan commit")
+  assert_eq(none.ok, true, "empty result is not an error")
+  http_mock_clear()
+}

--- a/tests/oauth_user_methods.harn
+++ b/tests/oauth_user_methods.harn
@@ -1,0 +1,101 @@
+import {
+  call,
+  oauth_user_device_code,
+  oauth_user_device_poll,
+  oauth_user_exchange_code,
+  oauth_user_refresh,
+} from "../src/lib"
+
+pipeline default() {
+  egress_policy({allow: ["github.test"], default: "deny"})
+  http_mock_clear()
+  let oauth_base = "https://github.test"
+  let client_id = "Iv1.abc123"
+  let opts = {oauth_base_url: oauth_base}
+  // Device code request.
+  http_mock(
+    "POST",
+    oauth_base + "/login/device/code",
+    {
+      status: 200,
+      body: json_stringify(
+        {
+          device_code: "dc-123",
+          user_code: "WDJB-MJHT",
+          verification_uri: "https://github.com/login/device",
+          expires_in: 900,
+          interval: 5,
+        },
+      ),
+    },
+  )
+  let device = oauth_user_device_code(client_id, "repo", opts)
+  assert_eq(device.device_code, "dc-123", "device code")
+  assert_eq(device.user_code, "WDJB-MJHT", "user code")
+  // Device poll: pending then granted.
+  http_mock(
+    "POST",
+    oauth_base + "/login/oauth/access_token",
+    {
+      responses: [
+        {status: 200, body: json_stringify({error: "authorization_pending"})},
+        {
+          status: 200,
+          body: json_stringify(
+            {
+              access_token: "ghu_user1",
+              token_type: "bearer",
+              scope: "repo",
+              expires_in: 28800,
+              refresh_token: "ghr_refresh1",
+              refresh_token_expires_in: 15897600,
+            },
+          ),
+        },
+      ],
+    },
+  )
+  let pending = oauth_user_device_poll(client_id, "dc-123", opts)
+  assert_eq(pending.error, "authorization_pending", "poll pending")
+  let granted = oauth_user_device_poll(client_id, "dc-123", opts)
+  assert_eq(granted.access_token, "ghu_user1", "granted user token")
+  assert_eq(granted.refresh_token, "ghr_refresh1", "granted refresh token")
+  // Web-flow code exchange.
+  http_mock(
+    "POST",
+    oauth_base + "/login/oauth/access_token",
+    {
+      status: 200,
+      body: json_stringify({access_token: "ghu_user2", refresh_token: "ghr_refresh2", expires_in: 28800}),
+    },
+  )
+  let exchanged = oauth_user_exchange_code(client_id, "web-code", opts + {client_secret: "shh"})
+  assert_eq(exchanged.access_token, "ghu_user2", "exchanged token")
+  // Refresh rotates the refresh token.
+  http_mock(
+    "POST",
+    oauth_base + "/login/oauth/access_token",
+    {
+      status: 200,
+      body: json_stringify({access_token: "ghu_user3", refresh_token: "ghr_rotated", expires_in: 28800}),
+    },
+  )
+  let refreshed = oauth_user_refresh(client_id, "ghr_refresh2", opts)
+  assert_eq(refreshed.access_token, "ghu_user3", "refreshed token")
+  assert_eq(refreshed.refresh_token, "ghr_rotated", "refresh token rotates")
+  // Missing client_id is rejected before any network call.
+  let bad = call("oauth.user.device_code", {})
+  assert(is_err(bad), "missing client_id rejected")
+  assert_eq(unwrap_err(bad).category, "schema_drift", "missing client_id category")
+  let calls = http_mock_calls()
+  assert_eq(json_parse(calls[0].body).client_id, client_id, "device code client id")
+  assert_eq(json_parse(calls[0].body).scope, "repo", "device code scope")
+  assert_eq(
+    json_parse(calls[1].body).grant_type,
+    "urn:ietf:params:oauth:grant-type:device_code",
+    "device poll grant type",
+  )
+  assert_eq(json_parse(calls[4].body).grant_type, "refresh_token", "refresh grant type")
+  assert_eq(json_parse(calls[4].body).refresh_token, "ghr_refresh2", "refresh sends old token")
+  http_mock_clear()
+}

--- a/tests/runner_methods.harn
+++ b/tests/runner_methods.harn
@@ -1,0 +1,139 @@
+import {
+  actions_runner_generate_jitconfig,
+  actions_runner_registration_token,
+  actions_runners_list,
+  call,
+} from "../src/lib"
+
+pipeline default() {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  let base = "https://github-api.test"
+  let token = "github-installation-token"
+  let auth = {api_base_url: base, installation_token: token}
+  // Repo-scope registration token.
+  http_mock(
+    "POST",
+    base + "/repos/octo-org/octo-repo/actions/runners/registration-token",
+    {
+      status: 201,
+      body: "{\"token\":\"AABBCC\",\"expires_at\":\"2026-04-20T18:00:00Z\"}",
+      headers: {"x-ratelimit-remaining": "10"},
+    },
+  )
+  let reg = actions_runner_registration_token({owner: "octo-org", repo: "octo-repo"}, auth)
+  assert_eq(reg.token, "AABBCC", "repo registration token")
+  // Org-scope remove token.
+  http_mock(
+    "POST",
+    base + "/orgs/octo-org/actions/runners/remove-token",
+    {status: 201, body: "{\"token\":\"DDEEFF\"}", headers: {"x-ratelimit-remaining": "9"}},
+  )
+  let rem = call("actions.runners.remove_token", auth + {org: "octo-org"})
+  assert_eq(rem.token, "DDEEFF", "org remove token")
+  // JIT config (modern stateless path).
+  http_mock(
+    "POST",
+    base + "/orgs/octo-org/actions/runners/generate-jitconfig",
+    {
+      status: 201,
+      body: "{\"runner\":{\"id\":77,\"name\":\"jit-1\"},\"encoded_jit_config\":\"ZW5jb2RlZA==\"}",
+      headers: {"x-ratelimit-remaining": "8"},
+    },
+  )
+  let jit = actions_runner_generate_jitconfig(
+    {org: "octo-org"},
+    "jit-1",
+    1,
+    ["self-hosted", "linux"],
+    auth + {work_folder: "_work"},
+  )
+  assert_eq(jit.runner.id, 77, "jit runner id")
+  // List runners (repo scope, with pagination).
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/actions/runners?per_page=5",
+    {
+      status: 200,
+      body: "{\"total_count\":1,\"runners\":[{\"id\":77,\"name\":\"jit-1\",\"status\":\"online\"}]}",
+      headers: {"x-ratelimit-remaining": "7"},
+    },
+  )
+  let runners = actions_runners_list({owner: "octo-org", repo: "octo-repo"}, auth + {per_page: 5})
+  assert_eq(runners.runners[0].id, 77, "list runners")
+  // Get + delete a runner.
+  http_mock(
+    "GET",
+    base + "/orgs/octo-org/actions/runners/77",
+    {status: 200, body: "{\"id\":77,\"name\":\"jit-1\"}", headers: {"x-ratelimit-remaining": "6"}},
+  )
+  let got = call("actions.runners.get", auth + {org: "octo-org", runner_id: 77})
+  assert_eq(got.id, 77, "get runner")
+  http_mock(
+    "DELETE",
+    base + "/orgs/octo-org/actions/runners/77",
+    {status: 204, body: "", headers: {"x-ratelimit-remaining": "5"}},
+  )
+  call("actions.runners.delete", auth + {org: "octo-org", runner_id: 77})
+  // Labels: add, replace, remove one.
+  http_mock(
+    "POST",
+    base + "/repos/octo-org/octo-repo/actions/runners/77/labels",
+    {status: 200, body: "{\"total_count\":3,\"labels\":[]}", headers: {"x-ratelimit-remaining": "4"}},
+  )
+  call(
+    "actions.runners.labels.add",
+    auth + {owner: "octo-org", repo: "octo-repo", runner_id: 77, labels: ["gpu"]},
+  )
+  http_mock(
+    "PUT",
+    base + "/repos/octo-org/octo-repo/actions/runners/77/labels",
+    {status: 200, body: "{\"total_count\":1,\"labels\":[]}", headers: {"x-ratelimit-remaining": "3"}},
+  )
+  call(
+    "actions.runners.labels.replace",
+    auth + {owner: "octo-org", repo: "octo-repo", runner_id: 77, labels: ["self-hosted"]},
+  )
+  http_mock(
+    "DELETE",
+    base + "/repos/octo-org/octo-repo/actions/runners/77/labels/gpu",
+    {status: 200, body: "{\"total_count\":1,\"labels\":[]}", headers: {"x-ratelimit-remaining": "2"}},
+  )
+  call(
+    "actions.runners.labels.remove",
+    auth + {owner: "octo-org", repo: "octo-repo", runner_id: 77, name: "gpu"},
+  )
+  // Runner groups (org only).
+  http_mock(
+    "POST",
+    base + "/orgs/octo-org/actions/runner-groups",
+    {status: 201, body: "{\"id\":3,\"name\":\"gpu-pool\"}", headers: {"x-ratelimit-remaining": "1"}},
+  )
+  let group = call(
+    "actions.runner_groups.create",
+    auth + {org: "octo-org", name: "gpu-pool", visibility: "selected"},
+  )
+  assert_eq(group.id, 3, "create runner group")
+  // Downloads.
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/actions/runners/downloads",
+    {
+      status: 200,
+      body: "[{\"os\":\"linux\",\"architecture\":\"x64\"}]",
+      headers: {"x-ratelimit-remaining": "1"},
+    },
+  )
+  let downloads = call("actions.runners.downloads", auth + {owner: "octo-org", repo: "octo-repo"})
+  assert_eq(downloads[0].os, "linux", "runner downloads")
+  // Scope validation: missing org and owner/repo.
+  let bad = call("actions.runners.list", auth)
+  assert(is_err(bad), "missing scope rejected")
+  assert_eq(unwrap_err(bad).category, "schema_drift", "missing scope category")
+  let calls = http_mock_calls()
+  assert_eq(calls[0].method, "POST", "registration token method")
+  assert_eq(json_parse(calls[2].body).name, "jit-1", "jitconfig body name")
+  assert_eq(json_parse(calls[2].body).work_folder, "_work", "jitconfig body work_folder")
+  assert_eq(json_parse(calls[6].body).labels[0], "gpu", "labels add body")
+  http_mock_clear()
+}


### PR DESCRIPTION
Additive C1 work on the pure-Harn GitHub connector (north-star connectors program). Does not break any existing method.

## What's added

**A. Self-hosted runner management** (repo `owner`+`repo` and org `org` scope):
`actions.runners.registration_token` / `remove_token` / `generate_jitconfig` (stateless single-use) / `list` / `get` / `delete` / `downloads`, `actions.runners.labels.list/add/replace/remove`, and `actions.runner_groups.list/create/get/update/delete` (org-only). Mutating methods documented as requiring repo `administration:write` or org `organization_self_hosted_runners:write`. Helpers: `actions_runner_registration_token`, `actions_runner_generate_jitconfig`, `actions_runners_list`.

**B. `@`-mention command extractor** (CPU-only, no network) in `normalize_inbound`. Issue, PR, and comment bodies are scanned for `@handle command args...`; a `mention` block (`{candidates, actor, command, handle, rest, issue_number?, comment_id?, html_url?}`) is added to the normalized payload. All `@mentions` are surfaced as `candidates` (downstream filters by bot identity). Exposed publicly via `github_extract_mentions(body)`.

**C. User-to-server OAuth** methods `oauth.user.device_code` / `device_poll` / `exchange_code` / `refresh` (+ matching helpers), posting to github.com (not the REST host) and independent of the App webhook flow. `ghu_` 8h / `ghr_` 6mo tokens rotate on refresh; the new `refresh_token` is returned. Adds the `oauth` connector capability.

**D. Async mergeable resolver** `pull_requests.resolve_mergeable` / `github_resolve_mergeable`: GETs the single-PR endpoint to trigger the async computation and polls with bounded backoff while `mergeable===null`/`mergeable_state=="unknown"`, returning `{mergeable, mergeable_state, is_conflict, attempts, resolved, ...}` (configurable `max_attempts`, default 4).

**E. Commit→PR resolver** `repos.commit_pulls` + `github_resolve_pr_for_sha(owner, repo, sha)`: prefers payload `pull_requests[]` and falls back to `GET /commits/{sha}/pulls` (forks have empty arrays; `status` events carry no PR). Reusable by the CircleCI/Buildkite connectors.

## Housekeeping
- Version `0.3.0` → `0.4.0`; README outbound/helper/permission tables and CHANGELOG updated.
- New smoke tests: `runner_methods.harn`, `mention_extraction.harn`, `oauth_user_methods.harn`, `mergeable_and_commit_pulls.harn`, plus an `issue_comment_mention` webhook fixture.

## Local CI (all green)
`harn check src`, `harn lint src`, `harn fmt --check src tests`, all 16 `tests/*.harn`, and `harn connector check .` (1 connector, 16 fixtures) pass. Package install smoke passes when the checkout dir is named `harn-github-connector` (as in CI).

Refs #93 (epic stays open for remaining C1 follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)