### PR TITLE
feat: expose github.app.installation_token call method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Expose `github.app.installation_token` as an outbound `call` method. It
+  returns the installation bearer token the connector already resolves
+  internally — self-minted from `app_id` + `installation_id` +
+  `private_key_pem`/`private_key_secret` (RS256 JWT exchange), or passed through
+  in direct/`gh-auth` modes — as `{token, token_mode, installation_id,
+  api_base_url}`. This lets an orchestrator (e.g. harn-cloud) obtain a token for
+  its own git operations without re-implementing JWT minting. No new privilege:
+  the caller must already hold the App credentials to mint.
+
 ## 0.4.0 - 2026-06-02
 
 - Add GitHub Actions self-hosted runner management methods supporting both repo

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -30,6 +30,7 @@ let GITHUB_OUTBOUND_METHODS = [
   "github.issue.create",
   "github.issue.comment",
   "github.branch.protection",
+  "github.app.installation_token",
   "api_call",
   "issues.create_comment",
   "issues.create",
@@ -258,6 +259,20 @@ pub fn call(method, args = {}) {
     return config
   }
   let cfg = unwrap(config)
+  if method == "github.app.installation_token" {
+    // Resolving `cfg` above already self-minted the installation token in
+    // app-credential mode (app_id + installation_id + private_key_pem/secret),
+    // or carried through a direct/gh-auth token. Expose it so an orchestrator
+    // (e.g. harn-cloud) can obtain a bearer token for its own git operations
+    // without re-implementing RS256 JWT minting. The caller must already hold
+    // the credentials, so this grants no privilege it did not already have.
+    return {
+      token: cfg.installation_token,
+      token_mode: cfg.token_mode,
+      installation_id: cfg.installation_id,
+      api_base_url: cfg.api_base_url,
+    }
+  }
   if method == "github.pr.list" {
     return __github_pr_list(args, cfg)
   }

--- a/tests/installation_token_method_smoke.harn
+++ b/tests/installation_token_method_smoke.harn
@@ -1,0 +1,53 @@
+import { call, reset_token_cache } from "../src/lib"
+
+fn fixture_key(harness: Harness) {
+  return harness.fs.read_text(path_join(cwd(), "tests/fixtures/github_app_test_key.pem"))
+}
+
+fn app_config(harness: Harness, now) {
+  return {
+    app_id: 12345,
+    installation_id: 77,
+    api_base_url: "https://api.github.test",
+    private_key_pem: fixture_key(harness),
+    now: now,
+    rate_limit_max_sleep_seconds: 0,
+  }
+}
+
+pipeline default() {
+  egress_policy({allow: ["github-api.test", "api.github.test"], default: "deny"})
+  reset_token_cache()
+  http_mock_clear()
+  // App-credential mode: the method self-mints a fresh installation token by
+  // exchanging an RS256 JWT, and returns it for the caller's own use.
+  http_mock(
+    "POST",
+    "https://api.github.test/app/installations/77/access_tokens",
+    {
+      status: 201,
+      body: "{\"token\":\"token-a\",\"expires_at\":\"2023-11-14T23:13:20Z\"}",
+      headers: {"x-ratelimit-remaining": "42"},
+    },
+  )
+  let minted = call("github.app.installation_token", app_config(harness, 1700000000))
+  assert_eq(minted.token, "token-a", "app-credential mode returns the minted token")
+  assert_eq(minted.token_mode, "jwt", "app-credential mode reports jwt token_mode")
+  assert_eq(minted.installation_id, 77, "app-credential mode echoes the installation id")
+  // Exactly one mint exchange happened (no spurious extra API calls).
+  let calls = http_mock_calls()
+  assert_eq(len(calls), 1, "only the token exchange was performed")
+  assert_eq(calls[0].headers.authorization, "[redacted]", "JWT bearer is redacted in call log")
+  // Direct-token mode: a pre-supplied installation token passes straight
+  // through with no network call.
+  http_mock_clear()
+  let direct = call(
+    "github.app.installation_token",
+    {api_base_url: "https://api.github.test", installation_token: "direct-xyz", installation_id: 77},
+  )
+  assert_eq(direct.token, "direct-xyz", "direct mode passes the supplied token through")
+  assert_eq(direct.token_mode, "direct", "direct mode reports direct token_mode")
+  assert_eq(len(http_mock_calls()), 0, "direct mode performs no network exchange")
+  reset_token_cache()
+  http_mock_clear()
+}


### PR DESCRIPTION
## What

Adds `github.app.installation_token` as an outbound `call` method on the GitHub connector. It returns the installation bearer token the connector **already** resolves internally as part of `__outbound_config` — self-minted from `app_id` + `installation_id` + `private_key_pem`/`private_key_secret` (RS256 JWT → `/app/installations/{id}/access_tokens` exchange), or passed straight through in `direct`/`gh-auth` modes — shaped as `{token, token_mode, installation_id, api_base_url}`.

## Why

This is the missing OSS primitive for H5 (harn-cloud connector north-star). harn-cloud's factory workers need an installation **bearer token for their own `git` operations** (clone/push), not just for connector API calls. The connector self-mints for its *own* calls but had no public surface to hand a token back. Rather than re-implement RS256 JWT minting in harn-cloud (which would violate the open-core boundary — credential minting is a general runtime primitive that belongs in Harn), an orchestrator can now call this method to obtain a token.

**No new privilege:** to mint, the caller must already supply the App credentials (`app_id` + `installation_id` + private key); this only exposes a value already derivable from those inputs.

## Tests

`tests/installation_token_method_smoke.harn`:
- App-credential mode mints via the RS256 JWT exchange and returns `token-a` / `token_mode = "jwt"` / `installation_id = 77`, with exactly one token exchange and the JWT bearer redacted in the call log.
- Direct-token mode passes a pre-supplied token through with `token_mode = "direct"` and **zero** network calls.

Verified locally: `harn run` (new + all existing tests pass), `harn fmt --check`, `harn check src`, `harn connector check . --provider github` (16 fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)