### PR TITLE
fix: binding id handling, jitconfig validation, and merge_safe DRY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- Fix `activate` corrupting caller-supplied binding ids: a misplaced paren
+  appended the binding index to every id (e.g. `primary` -> `primary0`), so a
+  webhook carrying `metadata.binding_id` could not resolve its binding-scoped
+  signing secret and was rejected with `missing_secret`. Ids are now preserved
+  verbatim and the index suffix only applies to the generated `binding-N`
+  fallback.
+- Fix `actions.runners.generate_jitconfig` silently POSTing a placeholder
+  `{error: "missing_name"}` body when `name` was omitted; it now returns a
+  `schema_drift` error before issuing any request.
+- Route `pulls.merge_safe` branch-protection lookups through the shared
+  `__github_branch_protection_raw` helper instead of re-implementing the
+  request and 404 handling, keeping protection semantics in one place.
 - Add author-mode-aware write paths for `pulls.create`,
   `repos.create_or_update_file`/`repos.put_content`, `repos.delete_file`, and
   `git.create_commit`. `author_mode=human` applies the supplied

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -194,7 +194,8 @@ pub fn activate(bindings = []) {
   var by_id = {}
   var seen_paths = {}
   for binding in bindings ?? [] {
-    let binding_id = binding?.binding_id ?? binding?.id ?? ("binding-" + to_string(len(by_id.keys())))
+    let fallback_id = "binding-" + to_string(len(by_id.keys()))
+    let binding_id = binding?.binding_id ?? binding?.id ?? fallback_id
     let path = binding?.path ?? binding?.match?.path
     if path != nil && path != "" {
       if seen_paths.get(path) {

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -194,7 +194,7 @@ pub fn activate(bindings = []) {
   var by_id = {}
   var seen_paths = {}
   for binding in bindings ?? [] {
-    let binding_id = (binding?.binding_id ?? binding?.id ?? "binding-") + to_string(len(by_id.keys()))
+    let binding_id = binding?.binding_id ?? binding?.id ?? ("binding-" + to_string(len(by_id.keys())))
     let path = binding?.path ?? binding?.match?.path
     if path != nil && path != "" {
       if seen_paths.get(path) {
@@ -1959,20 +1959,16 @@ fn __pulls_merge_safe(args, cfg) {
     return pull
   }
   let base_branch = pull?.base?.ref ?? args?.base_branch
-  let protection = __github_json(
-    "GET",
-    __github_api_url(
-      cfg.api_base_url,
-      "/repos/" + args.owner + "/" + args.repo + "/branches/" + url_encode(to_string(base_branch))
-        + "/protection",
-    ),
-    nil,
+  let protection_result = __github_branch_protection_raw(
+    {owner: to_string(args.owner), name: to_string(args.repo)},
+    base_branch,
     cfg,
   )
-  let protected = !is_err(protection)
-  if is_err(protection) && !contains(to_string(unwrap_err(protection)?.message ?? ""), "status 404") {
-    return protection
+  if is_err(protection_result) {
+    return protection_result
   }
+  let protection = unwrap(protection_result)
+  let protected = protection != nil
   if protected && !(args?.admin_override ?? false) {
     return __err(
       "protected_branch_requires_admin_override",
@@ -1995,11 +1991,7 @@ fn __pulls_merge_safe(args, cfg) {
   var result = {
     pull_request: pull,
     protected: protected,
-    branch_protection: if protected {
-      protection
-    } else {
-      nil
-    },
+    branch_protection: protection,
     merge: __merge_annotation(merged, args),
   }
   if args?.delete_branch ?? false {
@@ -2279,6 +2271,9 @@ fn __actions_runners_dispatch(method, args, cfg) {
     return __github_json("POST", __github_api_url(cfg.api_base_url, base + "/remove-token"), nil, cfg)
   }
   if method == "actions.runners.generate_jitconfig" {
+    if args?.name == nil || trim(to_string(args.name)) == "" {
+      return __err("schema_drift", "actions.runners.generate_jitconfig requires `name`")
+    }
     return __github_json(
       "POST",
       __github_api_url(cfg.api_base_url, base + "/generate-jitconfig"),
@@ -2328,11 +2323,7 @@ fn __actions_runners_dispatch(method, args, cfg) {
 }
 
 fn __runner_jitconfig_body(args) {
-  let name = args?.name
-  if name == nil || trim(to_string(name)) == "" {
-    return {error: "missing_name"}
-  }
-  var body = {name: to_string(name), runner_group_id: args?.runner_group_id ?? 1, labels: args?.labels ?? []}
+  var body = {name: to_string(args?.name), runner_group_id: args?.runner_group_id ?? 1, labels: args?.labels ?? []}
   if args?.work_folder != nil {
     body["work_folder"] = args.work_folder
   }

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -2324,7 +2324,11 @@ fn __actions_runners_dispatch(method, args, cfg) {
 }
 
 fn __runner_jitconfig_body(args) {
-  var body = {name: to_string(args?.name), runner_group_id: args?.runner_group_id ?? 1, labels: args?.labels ?? []}
+  var body = {
+    name: to_string(args?.name),
+    runner_group_id: args?.runner_group_id ?? 1,
+    labels: args?.labels ?? [],
+  }
   if args?.work_folder != nil {
     body["work_folder"] = args.work_folder
   }

--- a/tests/binding_secret_smoke.harn
+++ b/tests/binding_secret_smoke.harn
@@ -1,0 +1,21 @@
+import { activate, init, normalize_inbound, shutdown } from "../src/lib"
+import { fixture_raw } from "./helpers"
+
+// Regression: `activate` must preserve a caller-supplied binding id verbatim so
+// that a webhook carrying `metadata.binding_id` resolves the binding-scoped
+// signing secret. A previous bug appended a positional index to every id
+// (e.g. `primary` -> `primary0`), which broke the lookup and rejected the
+// webhook with `missing_secret`.
+pipeline default() {
+  let secret = "binding-scoped-secret"
+  shutdown()
+  // No ctx-level signing secret: verification must fall back to the binding.
+  init({})
+  let activated = activate([{id: "primary", path: "/github/events", signing_secret: secret}])
+  assert_eq(activated.bindings, 1, "one binding activated")
+  let raw = fixture_raw(harness, "issues_opened", secret, "issues", {metadata: {binding_id: "primary"}})
+  let result = normalize_inbound(raw)
+  assert_eq(result.type, "event", "binding-scoped signing secret verifies the webhook")
+  assert_eq(result.event.payload.issue.number, 7, "normalized issue number")
+  shutdown()
+}

--- a/tests/runner_methods.harn
+++ b/tests/runner_methods.harn
@@ -130,6 +130,11 @@ pipeline default() {
   let bad = call("actions.runners.list", auth)
   assert(is_err(bad), "missing scope rejected")
   assert_eq(unwrap_err(bad).category, "schema_drift", "missing scope category")
+  // JIT config without a runner name is rejected before any HTTP request,
+  // rather than POSTing a placeholder `{error: "missing_name"}` body.
+  let bad_jit = call("actions.runners.generate_jitconfig", auth + {org: "octo-org"})
+  assert(is_err(bad_jit), "jitconfig without name rejected")
+  assert_eq(unwrap_err(bad_jit).category, "schema_drift", "jitconfig missing name category")
   let calls = http_mock_calls()
   assert_eq(calls[0].method, "POST", "registration token method")
   assert_eq(json_parse(calls[2].body).name, "jit-1", "jitconfig body name")


### PR DESCRIPTION
## Summary

Fixes three unambiguous issues in the GitHub connector (`src/lib.harn`):

### 1. Bug — `activate()` corrupts caller-supplied binding ids
A misplaced paren made the index suffix apply to *every* binding id:

```harn
// before — always appends the index, even to explicit ids
let binding_id = (binding?.binding_id ?? binding?.id ?? "binding-") + to_string(len(by_id.keys()))
// after — index only feeds the generated fallback
let binding_id = binding?.binding_id ?? binding?.id ?? ("binding-" + to_string(len(by_id.keys())))
```

So an explicit id like `primary` was stored as `primary0`. A later inbound webhook carrying `metadata.binding_id: "primary"` then failed `bindings.get("primary")`, never resolved its binding-scoped signing secret, and was rejected with `missing_secret`.

### 2. Bug — `actions.runners.generate_jitconfig` POSTs a placeholder body when `name` is missing
`__runner_jitconfig_body` returned a plain `{error: "missing_name"}` dict, which was sent to GitHub as the request body instead of failing. It now returns a `schema_drift` error before any HTTP request, consistent with the other runner-method guards.

### 3. DRY — `pulls.merge_safe` re-implemented branch-protection fetching
The branch-protection GET + 404 handling was duplicated inline. It now routes through the existing `__github_branch_protection_raw` helper (which already centralizes the URL build and 404→`nil` semantics), behavior-preserving.

## Tests
- `tests/binding_secret_smoke.harn` (new): activates a binding with an explicit id and no ctx secret, then verifies an inbound webhook resolves the binding-scoped signing secret — fails without fix #1.
- `tests/runner_methods.harn`: asserts `generate_jitconfig` without `name` returns a `schema_drift` error before issuing a request (fix #2). The guard returns before any HTTP call, so existing `http_mock_calls()` indices are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXfShXWYTd6RC8TAvW1xMe)_