### PR TITLE
Emit GitHub reaction topics from normalized webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add semantic `reaction_topics` to normalized webhook payloads. Failed
+  check/workflow/status events now emit `github.reaction.ci_failure`, and dirty
+  pull requests emit `github.reaction.merge_conflict`, so hosted captains can
+  subscribe to stable reaction topics instead of re-deriving GitHub predicates.
 - Fix `activate` corrupting caller-supplied binding ids: a misplaced paren
   appended the binding index to every id (e.g. `primary` -> `primary0`), so a
   webhook carrying `metadata.binding_id` could not resolve its binding-scoped

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ fields for Harn consumers:
 | `provider` | Always `github`. |
 | `event` | GitHub event kind, such as `pull_request` or `merge_group`. |
 | `topic` | `github.<event>` or `github.<event>.<action>`. |
+| `reaction_topics` | Semantic `github.reaction.*` topics derived from the payload. |
 | `action` | GitHub payload action when present. |
 | `delivery_id` | `X-GitHub-Delivery`; also used for the dedupe key. |
 | `installation_id` | GitHub App installation id when present. |
@@ -117,6 +118,13 @@ Merge Captain and release consumers should subscribe to these topics:
 | `github.installation.<action>` | `installation`, `account`, `installation_state`, `suspended`, `revoked`, `repositories` |
 | `github.installation_repositories.<action>` | `installation`, `account`, `installation_state`, `suspended`, `revoked`, `repository_selection`, `repositories_added`, `repositories_removed` |
 | `github.release.<action>` | `release`, `release_id`, `tag_name`, `name`, `draft`, `prerelease`, `target_commitish`, `published_at`, `assets` |
+
+Semantic reaction topics:
+
+| Topic | Emitted when |
+|---|---|
+| `github.reaction.ci_failure` | A `check_run`, `check_suite`, `workflow_run`, or legacy `status` payload concludes in a failure/error state. |
+| `github.reaction.merge_conflict` | A pull request payload reports `mergeable_state: "dirty"`. |
 
 ## Outbound calls
 

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -104,6 +104,10 @@ const GITHUB_WEBHOOK_EVENTS = [
   "release",
 ]
 
+const GITHUB_CI_FAILURE_CONCLUSIONS = ["failure", "timed_out", "startup_failure", "action_required"]
+
+const GITHUB_CI_FAILURE_STATES = ["failure", "error"]
+
 const TOKEN_CACHE_KEY = "harn-github-connector.token_cache"
 
 const DEFAULT_TOKEN_REFRESH_SKEW_SECONDS = 300
@@ -140,6 +144,7 @@ pub fn payload_schema() {
         provider: {type: "string"},
         event: {type: "string"},
         topic: {type: "string"},
+        reaction_topics: {type: "array", items: {type: "string"}},
         action: {type: ["string", "null"]},
         delivery_id: {type: ["string", "null"]},
         installation_id: {type: ["integer", "null"]},
@@ -3359,6 +3364,7 @@ fn __normalize_github_payload(event_kind, raw, delivery_id, dedupe_key, occurred
     provider: GITHUB_PROVIDER_ID,
     event: event_kind,
     topic: __topic(event_kind, raw?.action),
+    reaction_topics: __reaction_topics(event_kind, raw),
     action: raw?.action,
     delivery_id: delivery_id,
     installation_id: raw?.installation?.id,
@@ -3612,6 +3618,36 @@ fn __normalize_github_payload(event_kind, raw, delivery_id, dedupe_key, occurred
     )
   }
   return __decorate_dashboard_payload(event_kind, common, dedupe_key, occurred_at)
+}
+
+fn __reaction_topics(event_kind, raw) {
+  if event_kind == "pull_request" && __pull_request_has_conflict(raw?.pull_request) {
+    return ["github.reaction.merge_conflict"]
+  }
+  if __ci_concluded_failed(event_kind, raw) {
+    return ["github.reaction.ci_failure"]
+  }
+  return []
+}
+
+fn __pull_request_has_conflict(pr) {
+  return lowercase(to_string(pr?.mergeable_state ?? "")) == "dirty"
+}
+
+fn __ci_concluded_failed(event_kind, raw) {
+  if event_kind == "status" {
+    return contains(GITHUB_CI_FAILURE_STATES, lowercase(to_string(raw?.state ?? "")))
+  }
+  if event_kind == "check_run" {
+    return contains(GITHUB_CI_FAILURE_CONCLUSIONS, lowercase(to_string(raw?.check_run?.conclusion ?? "")))
+  }
+  if event_kind == "check_suite" {
+    return contains(GITHUB_CI_FAILURE_CONCLUSIONS, lowercase(to_string(raw?.check_suite?.conclusion ?? "")))
+  }
+  if event_kind == "workflow_run" {
+    return contains(GITHUB_CI_FAILURE_CONCLUSIONS, lowercase(to_string(raw?.workflow_run?.conclusion ?? "")))
+  }
+  return false
 }
 
 const MENTION_HANDLE_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_/"

--- a/tests/fixtures/webhooks/check_run_failure.json
+++ b/tests/fixtures/webhooks/check_run_failure.json
@@ -1,0 +1,28 @@
+{
+  "action": "completed",
+  "check_run": {
+    "id": 8002,
+    "name": "Harn CI",
+    "status": "completed",
+    "conclusion": "failure",
+    "html_url": "https://github.com/octo-org/octo-repo/runs/8002",
+    "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "check_suite": {"id": 8101},
+    "pull_requests": [
+      {
+        "number": 42,
+        "head": {"ref": "feature/connector-fixture", "sha": "cccccccccccccccccccccccccccccccccccccccc"},
+        "base": {"ref": "main", "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+      }
+    ],
+    "started_at": "2026-04-20T16:00:00Z",
+    "completed_at": "2026-04-20T16:03:00Z"
+  },
+  "repository": {
+    "name": "octo-repo",
+    "full_name": "octo-org/octo-repo",
+    "owner": {"id": 2001, "login": "octo-org", "type": "Organization"}
+  },
+  "sender": {"id": 1001, "login": "octocat", "type": "User"},
+  "installation": {"id": 3001}
+}

--- a/tests/fixtures/webhooks/pull_request_dirty.json
+++ b/tests/fixtures/webhooks/pull_request_dirty.json
@@ -1,0 +1,31 @@
+{
+  "action": "synchronize",
+  "number": 42,
+  "pull_request": {
+    "number": 42,
+    "title": "Add connector fixture",
+    "state": "open",
+    "mergeable_state": "dirty",
+    "html_url": "https://github.com/octo-org/octo-repo/pull/42",
+    "created_at": "2026-04-20T12:00:00Z",
+    "updated_at": "2026-04-20T12:05:00Z",
+    "head": {
+      "ref": "feature/connector-fixture",
+      "sha": "cccccccccccccccccccccccccccccccccccccccc"
+    },
+    "base": {
+      "ref": "main",
+      "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "draft": false,
+    "merged": false,
+    "user": {"id": 1001, "login": "octocat", "type": "User"}
+  },
+  "repository": {
+    "name": "octo-repo",
+    "full_name": "octo-org/octo-repo",
+    "owner": {"id": 2001, "login": "octo-org", "type": "Organization"}
+  },
+  "sender": {"id": 1001, "login": "octocat", "type": "User"},
+  "installation": {"id": 3001}
+}

--- a/tests/fixtures/webhooks/status_error.json
+++ b/tests/fixtures/webhooks/status_error.json
@@ -1,0 +1,18 @@
+{
+  "id": 9102,
+  "sha": "cccccccccccccccccccccccccccccccccccccccc",
+  "state": "error",
+  "context": "legacy/status",
+  "target_url": "https://ci.example.test/octo-repo/9102",
+  "description": "Legacy CI failed before running",
+  "branches": [{"name": "main"}],
+  "created_at": "2026-04-20T16:05:00Z",
+  "updated_at": "2026-04-20T16:05:00Z",
+  "repository": {
+    "name": "octo-repo",
+    "full_name": "octo-org/octo-repo",
+    "owner": {"id": 2001, "login": "octo-org", "type": "Organization"}
+  },
+  "sender": {"id": 1001, "login": "octocat", "type": "User"},
+  "installation": {"id": 3001}
+}

--- a/tests/normalize_smoke.harn
+++ b/tests/normalize_smoke.harn
@@ -25,8 +25,15 @@ pipeline default() {
   )
   assert_eq(pr.event.payload.base_ref, "main", "normalized pr base ref")
   assert_eq(pr.event.payload.topic, "github.pull_request.opened", "normalized pr topic")
+  assert_eq(pr.event.payload.reaction_topics, [], "clean pull request has no reaction topics")
   assert_eq(pr.event.payload.sender.login, "octocat", "pull request actor")
   assert(pr.event.dedupe_key != "" && pr.event.dedupe_key != nil, "pr dedupe key populated")
+  const dirty_pr = github_normalize(fixture_raw(harness, "pull_request_dirty", secret, "pull_request"))
+  assert_eq(
+    dirty_pr.event.payload.reaction_topics,
+    ["github.reaction.merge_conflict"],
+    "dirty pull request emits merge-conflict reaction topic",
+  )
   const push = github_normalize(fixture_raw(harness, "push", secret, "push"))
   assert_eq(push.event.kind, "push", "push event kind")
   assert_eq(push.event.payload.after, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "push after")
@@ -46,6 +53,7 @@ pipeline default() {
   const workflow = github_normalize(fixture_raw(harness, "workflow_run_completed", secret, "workflow_run"))
   assert_eq(workflow.event.kind, "workflow_run", "workflow run event kind")
   assert_eq(workflow.event.payload.workflow_run.conclusion, "success", "workflow conclusion")
+  assert_eq(workflow.event.payload.reaction_topics, [], "green workflow has no reaction topics")
   assert_eq(workflow.event.payload.run_id, 6001, "workflow run id")
   assert_eq(workflow.event.payload.check_suite_id, 8101, "workflow suite id")
   assert_eq(workflow.event.payload.pull_request_number, 42, "workflow pr number")
@@ -55,9 +63,16 @@ pipeline default() {
   const check = github_normalize(fixture_raw(harness, "check_run_completed", secret, "check_run"))
   assert_eq(check.event.kind, "check_run", "check run event kind")
   assert_eq(check.event.payload.check_run.conclusion, "success", "check conclusion")
+  assert_eq(check.event.payload.reaction_topics, [], "green check has no reaction topics")
   assert_eq(check.event.payload.check_id, 8001, "check run id")
   assert_eq(check.event.payload.check_suite_id, 8101, "check suite id")
   assert_eq(check.event.payload.pull_request_number, 42, "check pr number")
+  const failed_check = github_normalize(fixture_raw(harness, "check_run_failure", secret, "check_run"))
+  assert_eq(
+    failed_check.event.payload.reaction_topics,
+    ["github.reaction.ci_failure"],
+    "failed check emits CI-failure reaction topic",
+  )
   const suite = github_normalize(fixture_raw(harness, "check_suite_requested", secret, "check_suite"))
   assert_eq(suite.event.kind, "check_suite", "check suite event kind")
   assert_eq(suite.event.payload.check_suite_id, 8101, "check suite normalized id")
@@ -66,6 +81,13 @@ pipeline default() {
   assert_eq(status.event.kind, "status", "status event kind")
   assert_eq(status.event.payload.status_id, 9101, "status normalized id")
   assert_eq(status.event.payload.head_sha, "cccccccccccccccccccccccccccccccccccccccc", "status sha")
+  assert_eq(status.event.payload.reaction_topics, [], "green status has no reaction topics")
+  const error_status = github_normalize(fixture_raw(harness, "status_error", secret, "status"))
+  assert_eq(
+    error_status.event.payload.reaction_topics,
+    ["github.reaction.ci_failure"],
+    "error status emits CI-failure reaction topic",
+  )
   const group = github_normalize(fixture_raw(harness, "merge_group_checks_requested", secret, "merge_group"))
   assert_eq(group.event.kind, "merge_group", "merge group event kind")
   assert_eq(group.event.payload.merge_group_id, 9201, "merge group id")


### PR DESCRIPTION
## Summary

Adds connector-promoted `reaction_topics` to normalized GitHub webhook payloads.

This gives downstream Harn/Harn Cloud workflows a stable semantic trigger surface for common repair-worthy events without reclassifying raw webhook JSON in each consumer.

## Changes

- Emits `github.reaction.merge_conflict` for dirty pull-request webhook payloads.
- Emits `github.reaction.ci_failure` for failed `check_run`, `check_suite`, `workflow_run`, and legacy `status` payloads.
- Adds `reaction_topics` to the payload schema and normalized payload envelope.
- Adds webhook fixtures and normalize smoke assertions for clean, conflict, failed-check, and legacy-status cases.
- Documents the new semantic reaction topics.

## Validation

- `harn fmt --check src tests`
- `for test in tests/*.harn; do harn run "$test" || exit 1; done`