### PR TITLE
Add GitHub-signed branch commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Add typed `github.branch.create_signed_commit` dispatch and
+  `github_create_signed_commit` helper. It uses GraphQL
+  `createCommitOnBranch`, requires an expected head OID, omits custom commit
+  identity fields, and fails closed unless GitHub reports a valid signature
+  made with its signing key.
 - Add semantic `reaction_topics` to normalized webhook payloads. Failed
   check/workflow/status events now emit `github.reaction.ci_failure`, and dirty
   pull requests emit `github.reaction.merge_conflict`, so hosted captains can

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Call methods through `call(method, args)` unless a named helper fits better.
 | Self-hosted runners | `actions.runners.registration_token`, `actions.runners.remove_token`, `actions.runners.generate_jitconfig`, `actions.runners.list`, `actions.runners.get`, `actions.runners.delete`, `actions.runners.downloads`, `actions.runners.labels.list`, `actions.runners.labels.add`, `actions.runners.labels.replace`, `actions.runners.labels.remove`, `actions.runner_groups.list`, `actions.runner_groups.create`, `actions.runner_groups.get`, `actions.runner_groups.update`, `actions.runner_groups.delete` |
 | User OAuth | `oauth.user.device_code`, `oauth.user.device_poll`, `oauth.user.exchange_code`, `oauth.user.refresh` |
 | Issues | `github.issue.create`, `github.issue.comment`, `issues.create_comment`, `issues.create`, `issues.create_with_template`, `issues.update`, `issues.add_labels` |
-| Repository and release data | `github.release.latest`, `github.release.assets`, `github.branch.protection`, `repos.get_content`, `repos.get_text`, `repos.create_or_update_file`, `repos.put_content`, `repos.delete_file`, `repos.get_latest_release`, `repos.list_release_assets`, `repos.get_branch_protection`, `git.create_commit`, `git.delete_ref` |
+| Repository and release data | `github.release.latest`, `github.release.assets`, `github.branch.protection`, `github.branch.create_signed_commit`, `repos.get_content`, `repos.get_text`, `repos.create_or_update_file`, `repos.put_content`, `repos.delete_file`, `repos.get_latest_release`, `repos.list_release_assets`, `repos.get_branch_protection`, `git.create_commit`, `git.delete_ref` |
 | Merge queue | `github.merge_queue.entries`, `github.merge_queue.enqueue` |
 | Raw access | `api_call`, `graphql` |
 
@@ -165,6 +165,7 @@ Named helpers:
 | `github_close_pr(owner, repo, pull_number, comment, options)` | Close a PR and optionally post a final comment. |
 | `github_resolve_mergeable(owner, repo, pull_number, options)` | Resolve a PR's async `mergeable`/`mergeable_state` with bounded polling; returns `{mergeable, mergeable_state, is_conflict, ...}`. |
 | `github_resolve_pr_for_sha(owner, repo, sha, options)` | Resolve the PR for a commit SHA, preferring payload `pull_requests[]` and falling back to `repos.commit_pulls`. |
+| `github_create_signed_commit(request, options)` | Atomically append file additions/deletions at an expected head OID through GitHub's verified App-signing path. |
 | `github_extract_mentions(body)` | Pure string parse of `@handle command args...` mentions in a body. |
 | `actions_runner_registration_token(scope, options)` | Create a self-hosted runner registration token (`scope` is `{org}` or `{owner, repo}`). |
 | `actions_runner_generate_jitconfig(scope, name, runner_group_id, labels, options)` | Generate a stateless single-use JIT runner config. |

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -30,6 +30,7 @@ const GITHUB_OUTBOUND_METHODS = [
   "github.issue.create",
   "github.issue.comment",
   "github.branch.protection",
+  "github.branch.create_signed_commit",
   "github.app.installation_token",
   "api_call",
   "issues.create_comment",
@@ -107,6 +108,30 @@ const GITHUB_WEBHOOK_EVENTS = [
 const GITHUB_CI_FAILURE_CONCLUSIONS = ["failure", "timed_out", "startup_failure", "action_required"]
 
 const GITHUB_CI_FAILURE_STATES = ["failure", "error"]
+
+type GithubCommitFileAddition = {path: string, contents_base64: string}
+
+type GithubCommitFileDeletion = {path: string}
+
+type GithubSignedCommitRequest = {
+  owner: string,
+  repo: string,
+  branch: string,
+  expected_head_oid: string,
+  headline: string,
+  body?: string,
+  additions: list<GithubCommitFileAddition>,
+  deletions: list<GithubCommitFileDeletion>,
+}
+
+type GithubSignedCommitReceipt = {
+  oid: string,
+  url: string,
+  branch: string,
+  signature_valid: bool,
+  signed_by_github: bool,
+  signature_state: string,
+}
 
 const TOKEN_CACHE_KEY = "harn-github-connector.token_cache"
 
@@ -334,6 +359,9 @@ pub fn call(method, args = {}) {
   }
   if method == "github.branch.protection" {
     return __github_branch_protection(args, cfg)
+  }
+  if method == "github.branch.create_signed_commit" {
+    return __github_create_signed_commit(args, cfg)
   }
   if method == "api_call" {
     return __api_call(args, cfg)
@@ -599,6 +627,30 @@ pub fn pulls_merge_safe(owner, repo, number, options = nil) {
 pub fn pulls_enable_auto_merge(owner, repo, number, options = nil) {
   const opts = options ?? {}
   return call("github.pr.enable_auto_merge", opts + {owner: owner, repo: repo, pull_number: number})
+}
+
+/**
+ * Atomically append a GitHub-signed commit to a branch. GitHub App callers
+ * must not supply custom author, committer, or signature fields: GitHub then
+ * signs the commit itself and marks it verified. `expected_head_oid` is the
+ * publication lease and makes stale-head races fail closed.
+ */
+pub fn github_create_signed_commit(request: GithubSignedCommitRequest, options = nil) {
+  const opts = options ?? {}
+  return call(
+    "github.branch.create_signed_commit",
+    opts
+      + {
+      owner: request.owner,
+      repo: request.repo,
+      branch: request.branch,
+      expected_head_oid: request.expected_head_oid,
+      headline: request.headline,
+      body: request.body,
+      additions: request.additions,
+      deletions: request.deletions,
+    },
+  )
 }
 
 /** Dispatch a workflow_dispatch workflow and request run details when GitHub supports them. */
@@ -2656,6 +2708,151 @@ mutation HarnGithubConnectorEnableAutoMerge($pullRequestId: ID!, $mergeMethod: P
       autoMergeRequest {
         enabledAt
         mergeMethod
+      }
+    }
+  }
+}
+"""
+}
+
+fn __github_create_signed_commit(args, cfg) {
+  const owner = trim(to_string(args?.owner ?? ""))
+  const repo = trim(to_string(args?.repo ?? ""))
+  const branch = trim(to_string(args?.branch ?? ""))
+  const expected_head_oid = trim(to_string(args?.expected_head_oid ?? args?.expectedHeadOid ?? ""))
+  const headline = trim(to_string(args?.headline ?? ""))
+  if owner == "" || repo == "" || branch == "" || expected_head_oid == "" || headline == "" {
+    return __err(
+      "schema_drift",
+      "github.branch.create_signed_commit requires owner, repo, branch, expected_head_oid, and headline",
+    )
+  }
+  const additions_result = __github_signed_commit_additions(args?.additions ?? [])
+  if is_err(additions_result) {
+    return additions_result
+  }
+  const additions = unwrap(additions_result)
+  const deletions_result = __github_signed_commit_deletions(args?.deletions ?? [])
+  if is_err(deletions_result) {
+    return deletions_result
+  }
+  const deletions = unwrap(deletions_result)
+  if len(additions) == 0 && len(deletions) == 0 {
+    return __err("schema_drift", "github.branch.create_signed_commit requires at least one file change")
+  }
+  for addition in additions {
+    for deletion in deletions {
+      if addition.path == deletion.path {
+        return __err(
+          "schema_drift",
+          "github.branch.create_signed_commit cannot add and delete the same path `" + addition.path
+            + "`",
+        )
+      }
+    }
+  }
+  let message = {headline: headline}
+  const body = trim(to_string(args?.body ?? ""))
+  if body != "" {
+    message["body"] = body
+  }
+  const payload = __github_json(
+    "POST",
+    __github_api_url(cfg.api_base_url, "/graphql"),
+    {
+      query: __create_commit_on_branch_mutation(),
+      variables: {
+        input: {
+          branch: {repositoryNameWithOwner: owner + "/" + repo, branchName: branch},
+          expectedHeadOid: expected_head_oid,
+          message: message,
+          fileChanges: {additions: additions, deletions: deletions},
+        },
+      },
+    },
+    cfg,
+  )
+  if is_err(payload) {
+    return payload
+  }
+  if payload?.errors != nil && len(payload.errors) != 0 {
+    return __err("graphql", "github createCommitOnBranch returned errors: " + json_stringify(payload.errors))
+  }
+  const result = payload?.data?.createCommitOnBranch
+  const commit = result?.commit
+  const signature = commit?.signature
+  if commit?.oid == nil || trim(to_string(commit.oid)) == "" {
+    return __err("schema_drift", "github createCommitOnBranch returned no commit oid")
+  }
+  if signature?.isValid != true || signature?.wasSignedByGitHub != true || signature?.state != "VALID" {
+    return __err(
+      "signature_invalid",
+      "github createCommitOnBranch did not return a valid GitHub-generated signature",
+    )
+  }
+  const receipt: GithubSignedCommitReceipt = {
+    oid: to_string(commit.oid),
+    url: to_string(commit.url ?? ""),
+    branch: to_string(result?.ref?.name ?? branch),
+    signature_valid: true,
+    signed_by_github: true,
+    signature_state: to_string(signature.state),
+  }
+  return receipt
+}
+
+fn __github_signed_commit_additions(raw) {
+  let additions = []
+  let seen = {}
+  for item in raw {
+    const path = trim(to_string(item?.path ?? ""))
+    const contents = trim(to_string(item?.contents_base64 ?? item?.contents ?? ""))
+    if path == "" || contents == "" {
+      return __err("schema_drift", "signed commit additions require path and contents_base64")
+    }
+    if seen.get(path) ?? false {
+      return __err("schema_drift", "signed commit additions contain duplicate path `" + path + "`")
+    }
+    seen[path] = true
+    additions = additions + [{path: path, contents: contents}]
+  }
+  return Ok(additions)
+}
+
+fn __github_signed_commit_deletions(raw) {
+  let deletions = []
+  let seen = {}
+  for item in raw {
+    const path = trim(to_string(item?.path ?? ""))
+    if path == "" {
+      return __err("schema_drift", "signed commit deletions require path")
+    }
+    if seen.get(path) ?? false {
+      return __err("schema_drift", "signed commit deletions contain duplicate path `" + path + "`")
+    }
+    seen[path] = true
+    deletions = deletions + [{path: path}]
+  }
+  return Ok(deletions)
+}
+
+fn __create_commit_on_branch_mutation() {
+  return """
+mutation HarnGithubConnectorCreateCommitOnBranch($input: CreateCommitOnBranchInput!) {
+  createCommitOnBranch(input: $input) {
+    commit {
+      oid
+      url
+      signature {
+        isValid
+        state
+        wasSignedByGitHub
+      }
+    }
+    ref {
+      name
+      target {
+        oid
       }
     }
   }

--- a/tests/signed_commit.harn
+++ b/tests/signed_commit.harn
@@ -1,0 +1,113 @@
+import { github_create_signed_commit } from "../src/lib"
+
+fn auth(base: string) -> dict {
+  return {api_base_url: base, installation_token: "github-app-installation-token"}
+}
+
+fn request() -> dict {
+  return {
+    owner: "burin-labs",
+    repo: "burin-code",
+    branch: "release/harn-v0.10.8",
+    expected_head_oid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    headline: "Repin Harn to v0.10.8",
+    body: "Release Train Autopilot",
+    additions: [
+      {path: ".harn-version", contents_base64: base64_encode("v0.10.8\n")},
+      {path: "VERSION", contents_base64: base64_encode("0.10.8\n")},
+    ],
+    deletions: [{path: "changelog.d/old.changed.md"}],
+  }
+}
+
+pipeline test_create_signed_commit_uses_atomic_github_signed_mutation(task) {
+  egress_policy({allow: ["api.github.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://api.github.test"
+  http_mock(
+    "POST",
+    base + "/graphql",
+    {
+      status: 200,
+      body: json_stringify(
+        {
+          data: {
+            createCommitOnBranch: {
+              commit: {
+                oid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                url: "https://github.com/burin-labs/burin-code/commit/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                signature: {isValid: true, state: "VALID", wasSignedByGitHub: true},
+              },
+              ref: {name: "release/harn-v0.10.8", target: {oid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}},
+            },
+          },
+        },
+      ),
+    },
+  )
+  const receipt = github_create_signed_commit(request(), auth(base))
+  assert_eq(receipt.oid, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "commit oid")
+  assert_eq(receipt.signature_valid, true, "signature valid")
+  assert_eq(receipt.signed_by_github, true, "signed by GitHub")
+  assert_eq(receipt.signature_state, "VALID", "signature state")
+  const calls = http_mock_calls()
+  assert_eq(len(calls), 1, "one atomic GraphQL request")
+  const payload = json_parse(calls[0].body)
+  const input = payload.variables.input
+  assert_eq(input.branch.repositoryNameWithOwner, "burin-labs/burin-code", "repository")
+  assert_eq(input.branch.branchName, "release/harn-v0.10.8", "branch")
+  assert_eq(input.expectedHeadOid, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "expected head lease")
+  assert_eq(input.fileChanges.additions[0].path, ".harn-version", "addition path")
+  assert_eq(input.fileChanges.deletions[0].path, "changelog.d/old.changed.md", "deletion path")
+  assert_eq(input.author, nil, "no custom author")
+  assert_eq(input.committer, nil, "no custom committer")
+  assert_eq(input.signature, nil, "no custom signature")
+  assert(contains(payload.query, "createCommitOnBranch"), "signed commit mutation")
+  http_mock_clear()
+}
+
+pipeline test_create_signed_commit_fails_closed_on_unverified_signature(task) {
+  egress_policy({allow: ["api.github.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://api.github.test"
+  http_mock(
+    "POST",
+    base + "/graphql",
+    {
+      status: 200,
+      body: json_stringify(
+        {
+          data: {
+            createCommitOnBranch: {
+              commit: {
+                oid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                url: "https://github.com/burin-labs/burin-code/commit/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                signature: {isValid: false, state: "UNSIGNED", wasSignedByGitHub: false},
+              },
+              ref: {name: "release/harn-v0.10.8"},
+            },
+          },
+        },
+      ),
+    },
+  )
+  const result = github_create_signed_commit(request(), auth(base))
+  assert(is_err(result), "unverified commit rejected")
+  assert_eq(unwrap_err(result).code, "signature_invalid", "signature error code")
+  http_mock_clear()
+}
+
+pipeline test_create_signed_commit_rejects_overlapping_changes_before_network(task) {
+  http_mock_clear()
+  const result = github_create_signed_commit(
+    request()
+      + {
+      additions: [{path: "VERSION", contents_base64: base64_encode("0.10.8\n")}],
+      deletions: [{path: "VERSION"}],
+    },
+    auth("https://api.github.test"),
+  )
+  assert(is_err(result), "overlapping change rejected")
+  assert_eq(unwrap_err(result).code, "schema_drift", "overlap error code")
+  assert_eq(len(http_mock_calls()), 0, "no network request")
+}


### PR DESCRIPTION
## What changed

- add a typed `github.branch.create_signed_commit` method and `github_create_signed_commit` helper
- publish file additions and deletions atomically through GraphQL `createCommitOnBranch`
- require an expected head OID so stale publication races fail closed
- reject empty, duplicate, and add/delete-overlapping file sets before network dispatch
- return a normalized receipt only when GitHub reports a valid signature made with its signing key

## Why

Hosted coding workers cannot safely inherit a machine user's Git signing agent, and a long-lived bot signing key creates unnecessary custody and rotation burden. GitHub's App-authenticated `createCommitOnBranch` mutation is the native path: GitHub authors and signs the commit, marks it verified, and atomically compares the expected branch head.

## Impact

Harn Cloud workers can publish verified commits into repositories with required-signature rules without weakening organization policy or exposing signing material to an agent. This is the publication prerequisite for promoting Release Train Autopilot beyond observe/shadow mode.

## Root cause

The connector exposed raw GraphQL and low-level Git commit methods but no typed, fail-closed operation that combined GitHub App identity, automatic signing, expected-head arbitration, and a verification receipt.

## Validation

- every `tests/*.harn` file executed successfully
- `harn check src`
- `harn lint src`
- `harn fmt --check src tests`
- `harn connector check . --provider github`
- `git diff --check`

GitHub documents that `createCommitOnBranch` commits are automatically signed when supported and marked verified. The connector additionally queries `signature { isValid state wasSignedByGitHub }` and refuses to return success unless all three fields prove the expected signature.
