### PR TITLE
Add typed release lookup by tag

### DIFF
--- a/changelog.d/153.added.md
+++ b/changelog.d/153.added.md
@@ -1,0 +1,1 @@
+Added typed release lookup by exact tag so automation no longer assembles raw GitHub API paths.

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -25,6 +25,7 @@ const GITHUB_OUTBOUND_METHODS = [
   "github.actions.runs",
   "github.actions.run",
   "github.actions.logs",
+  "github.release.view",
   "github.release.latest",
   "github.release.assets",
   "github.merge_queue.entries",
@@ -354,6 +355,9 @@ pub fn call(method, args = {}) {
   }
   if method == "github.actions.logs" {
     return __github_actions_logs(args, cfg)
+  }
+  if method == "github.release.view" {
+    return __github_release_view(args, cfg)
   }
   if method == "github.release.latest" {
     return __github_release_latest(args, cfg)
@@ -822,6 +826,16 @@ pub fn repos_list_release_assets(owner, repo, release_id, options = nil) {
 pub fn github_latest_release(owner, repo, options = nil) {
   const opts = options ?? {}
   return call("github.release.latest", opts + {owner: owner, repo: repo})
+}
+
+/** Fetch release metadata by tag, or the latest release when the tag is nil. */
+pub fn github_release(owner, repo, tag = nil, options = nil) {
+  const opts = options ?? {}
+  let args = opts + {owner: owner, repo: repo}
+  if tag != nil {
+    args["tag"] = tag
+  }
+  return call("github.release.view", args)
 }
 
 /**
@@ -1807,6 +1821,42 @@ fn __github_release_latest(args, cfg) {
   }
   const r = unwrap(repo)
   const release = __repos_get_latest_release(args + {owner: r.owner, repo: r.name}, cfg)
+  if is_err(release) {
+    return __release_error_envelope(r.full_name, unwrap_err(release))
+  }
+  return __release_envelope(r.full_name, unwrap(release))
+}
+
+fn __github_release_view(args, cfg) {
+  const repo = __repo_parts(args)
+  if is_err(repo) {
+    return __release_error_envelope(nil, unwrap_err(repo))
+  }
+  const r = unwrap(repo)
+  const raw_tag = args?.tag
+  if raw_tag == nil {
+    return __github_release_latest(args, cfg)
+  }
+  const tag = trim(to_string(raw_tag))
+  if tag == "" {
+    return __release_error_envelope(
+      r.full_name,
+      {
+        code: "schema_drift",
+        category: "schema_drift",
+        message: "github.release.view tag must be non-empty",
+      },
+    )
+  }
+  const release = __github_json(
+    "GET",
+    __github_api_url(
+      cfg.api_base_url,
+      "/repos/" + r.owner + "/" + r.name + "/releases/tags/" + url_encode(tag),
+    ),
+    nil,
+    cfg,
+  )
   if is_err(release) {
     return __release_error_envelope(r.full_name, unwrap_err(release))
   }

--- a/tests/release_view.harn
+++ b/tests/release_view.harn
@@ -1,0 +1,77 @@
+import { call, github_release } from "../src/lib"
+
+fn release_fixture(tag) {
+  return {
+    id: 701,
+    tag_name: tag,
+    name: "Release " + tag,
+    draft: false,
+    prerelease: true,
+    html_url: "https://github.com/octo-org/octo-repo/releases/tag/" + tag,
+    published_at: "2026-07-13T00:00:00Z",
+    assets: [{id: 11, name: "harn.tar.gz"}],
+  }
+}
+
+pipeline test_release_view_by_tag(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://github-api.test"
+  const auth = {api_base_url: base, installation_token: "token"}
+  const tag = "v1.2.3+build/7"
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/releases/tags/v1.2.3%2Bbuild%2F7",
+    {status: 200, body: json_stringify(release_fixture(tag)), headers: {"x-ratelimit-remaining": "10"}},
+  )
+  const release = github_release("octo-org", "octo-repo", tag, auth)
+  assert(release.ok, "release view succeeds")
+  assert_eq(release.repo, "octo-org/octo-repo", "repo is normalized")
+  assert_eq(release.tag_name, tag, "tag is preserved")
+  assert_eq(release.asset_names, ["harn.tar.gz"], "assets use the stable envelope")
+  assert_eq(len(http_mock_calls()), 1, "exactly one request")
+}
+
+pipeline test_release_view_latest_and_invalid_tag(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://github-api.test"
+  const auth = {api_base_url: base, installation_token: "token"}
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/releases/latest",
+    {
+      status: 200,
+      body: json_stringify(release_fixture("v2.0.0")),
+      headers: {"x-ratelimit-remaining": "10"},
+    },
+  )
+  const latest = call("github.release.view", auth + {repo: "octo-org/octo-repo"})
+  assert(latest.ok, "nil tag delegates to latest")
+  assert_eq(latest.tag_name, "v2.0.0", "latest tag")
+  http_mock_clear()
+  const invalid = github_release("octo-org", "octo-repo", "   ", auth)
+  assert_eq(invalid.ok, false, "blank tag fails closed")
+  assert_eq(invalid.error.code, "schema_drift", "blank tag error category")
+  assert_eq(len(http_mock_calls()), 0, "blank tag performs no request")
+}
+
+pipeline test_release_view_provider_error(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://github-api.test"
+  const auth = {api_base_url: base, installation_token: "token"}
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/releases/tags/v9.9.9",
+    {
+      status: 404,
+      body: json_stringify({message: "Not Found"}),
+      headers: {"x-ratelimit-remaining": "10"},
+    },
+  )
+  const missing = github_release("octo-org", "octo-repo", "v9.9.9", auth)
+  assert_eq(missing.ok, false, "provider failure remains typed")
+  assert_eq(missing.repo, "octo-org/octo-repo", "error keeps repo identity")
+  assert(missing.error != nil, "provider error is retained")
+}


### PR DESCRIPTION
## Summary
- add canonical `github.release.view` dispatch and public `github_release` helper
- fetch an exact release by URL-encoded tag or delegate nil tags to the existing latest-release path
- preserve the existing stable release/error envelope

## Verification
- focused release-view fixtures: 3/3
- connector orchestration/repository/signed-commit suite: 23/23
- exact encoded URL and one-request assertion
- blank-tag zero-request falsifier
- provider error envelope
- full source check/format and diff check

Closes #153

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-github-connector/pr/154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786508288&installation_id=145974243&pr_number=154&repository=burin-labs%2Fharn-github-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-github-connector%2Fpull%2F154&signature=20b360cd60433398da4b0695ca3a7eb60d26cf78459e0ef1581c66c9eb6abc1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->