### PR TITLE
Honor explicit GitHub auth fallback policy

### DIFF
--- a/changelog.d/155.fixed.md
+++ b/changelog.d/155.fixed.md
@@ -1,0 +1,1 @@
+Explicit `allow_gh_auth_fallback` policy now overrides ambient environment configuration, so strict in-process callers can guarantee that connector authentication never spawns the GitHub CLI.

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -117,6 +117,8 @@ type GithubCommitFileAddition = {path: string, contents_base64: string}
 
 type GithubCommitFileDeletion = {path: string}
 
+type GithubAuthFallbackPolicy = {allow_gh_auth_fallback?: bool, gh_auth_fallback?: bool}
+
 type GithubSignedCommitRequest = {
   owner: string,
   repo: string,
@@ -5255,10 +5257,25 @@ fn __config_keys() {
   ]
 }
 
+/** Resolve gh-auth fallback with explicit caller policy ahead of ambient configuration. */
+pub fn github_auth_fallback_enabled(
+  args: GithubAuthFallbackPolicy = {},
+  environment_enabled: bool = false,
+) -> bool {
+  if args.keys().contains("allow_gh_auth_fallback") {
+    return args.allow_gh_auth_fallback ?? false
+  }
+  if args.keys().contains("gh_auth_fallback") {
+    return args.gh_auth_fallback ?? false
+  }
+  return environment_enabled
+}
+
 fn __allow_gh_auth_fallback(args) {
-  const direct = args?.allow_gh_auth_fallback ?? false
-  const alias = args?.gh_auth_fallback ?? false
-  return direct || alias || harness.env.get_or("HARN_GITHUB_ALLOW_GH_AUTH_FALLBACK", "") == "1"
+  return github_auth_fallback_enabled(
+    args,
+    harness.env.get_or("HARN_GITHUB_ALLOW_GH_AUTH_FALLBACK", "") == "1",
+  )
 }
 
 fn __gh_auth_token(args) {

--- a/tests/auth_fallback.harn
+++ b/tests/auth_fallback.harn
@@ -1,0 +1,40 @@
+import { github_auth_fallback_enabled } from "../src/lib"
+
+pipeline test_explicit_canonical_policy_dominates_environment(task) {
+  assert_eq(
+    github_auth_fallback_enabled({allow_gh_auth_fallback: false}, true),
+    false,
+    "explicit opt-out dominates an enabled environment default",
+  )
+  assert_eq(
+    github_auth_fallback_enabled({allow_gh_auth_fallback: true}, false),
+    true,
+    "explicit opt-in dominates a disabled environment default",
+  )
+}
+
+pipeline test_canonical_policy_dominates_legacy_alias(task) {
+  assert_eq(
+    github_auth_fallback_enabled({allow_gh_auth_fallback: false, gh_auth_fallback: true}, true),
+    false,
+    "canonical opt-out dominates the legacy alias and environment",
+  )
+}
+
+pipeline test_legacy_alias_precedes_environment_when_canonical_is_absent(task) {
+  assert_eq(
+    github_auth_fallback_enabled({gh_auth_fallback: false}, true),
+    false,
+    "legacy explicit opt-out dominates the environment default",
+  )
+  assert_eq(
+    github_auth_fallback_enabled({gh_auth_fallback: true}, false),
+    true,
+    "legacy explicit opt-in remains supported",
+  )
+}
+
+pipeline test_environment_is_only_the_absent_option_default(task) {
+  assert_eq(github_auth_fallback_enabled({}, true), true, "enabled environment default")
+  assert_eq(github_auth_fallback_enabled({}, false), false, "disabled environment default")
+}


### PR DESCRIPTION
Closes #155.

Makes caller-supplied auth fallback policy authoritative over ambient environment defaults. The resolver is typed and pure, with deterministic coverage for canonical/alias/environment precedence. This lets strict in-process orchestrators guarantee that the connector will not spawn the GitHub CLI.

Validation:
- harn fmt --check src tests
- harn check src
- harn lint src
- every tests/*.harn via harn run
- harn connector check . (16 fixtures)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-github-connector/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786510117&installation_id=145974243&pr_number=156&repository=burin-labs%2Fharn-github-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-github-connector%2Fpull%2F156&signature=39e45dea1cc697130c9ea27935cd52c0601283f618c96808c4df5713e50ec7f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->