### PR TITLE
Make typed PR listing and GraphQL fail closed

### DIFF
--- a/changelog.d/157.fixed.md
+++ b/changelog.d/157.fixed.md
@@ -1,0 +1,1 @@
+Typed pull-request listing now owner-qualifies bare head branches, implements merged-state filtering over GitHub's closed-PR REST contract, rejects unsupported states before I/O, and promotes GraphQL protocol errors instead of returning false successes.

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -628,12 +628,19 @@ pub fn call(method, args = {}) {
       cfg,
     )
   }
-  return __github_json(
+  const graph = __github_json(
     "POST",
     __github_api_url(cfg.api_base_url, "/graphql"),
     {query: args.query, variables: args.variables ?? {}},
     cfg,
   )
+  if is_err(graph) {
+    return graph
+  }
+  if graph?.errors != nil && len(graph.errors) > 0 {
+    return __err("graphql", "github GraphQL returned errors: " + json_stringify(graph.errors))
+  }
+  return graph
 }
 
 /** List PRs in the same shape consumed by managed merge_captain. */
@@ -1576,7 +1583,20 @@ fn __github_pr_list(args, cfg) {
     return repo
   }
   const r = unwrap(repo)
-  const filters = args?.filters ?? args ?? {}
+  let filters = (args?.filters ?? args ?? {}) + {}
+  const requested_state = lowercase(to_string(filters.state ?? "open"))
+  if !["open", "closed", "all", "merged"].contains(requested_state) {
+    return __err("schema_drift", "github.pr.list state must be open, closed, all, or merged")
+  }
+  filters["state"] = if requested_state == "merged" {
+    "closed"
+  } else {
+    requested_state
+  }
+  const head = trim(to_string(filters.head ?? ""))
+  if head != "" && !contains(head, ":") {
+    filters["head"] = r.owner + ":" + head
+  }
   const pulls = __github_json(
     "GET",
     __github_api_url(
@@ -1591,6 +1611,9 @@ fn __github_pr_list(args, cfg) {
   }
   let typed = []
   for pull in pulls {
+    if requested_state == "merged" && pull?.merged_at == nil && !(pull?.merged ?? false) {
+      continue
+    }
     typed = typed + [__typed_pr_summary(pull)]
   }
   return typed

--- a/tests/orchestration_helpers.harn
+++ b/tests/orchestration_helpers.harn
@@ -482,7 +482,7 @@ pipeline test_find_open_pr_matches_by_head_and_filters_labels(task) {
   http_mock_clear()
   http_mock(
     "GET",
-    BASE + "/repos/octo-org/octo-repo/pulls?state=open&head=feature%2Ffoo&base=main",
+    BASE + "/repos/octo-org/octo-repo/pulls?state=open&head=octo-org%3Afeature%2Ffoo&base=main",
     {
       status: 200,
       body: json_stringify(

--- a/tests/pr_list_contract.harn
+++ b/tests/pr_list_contract.harn
@@ -1,0 +1,122 @@
+import { call } from "../src/lib"
+
+fn auth(base) {
+  return {api_base_url: base, installation_token: "test-token"}
+}
+
+fn pull_fixture(number, head, merged_at = nil) {
+  return {
+    number: number,
+    title: "PR " + to_string(number),
+    state: "closed",
+    merged_at: merged_at,
+    html_url: "https://github.com/octo-org/octo-repo/pull/" + to_string(number),
+    base: {ref: "main", repo: {full_name: "octo-org/octo-repo"}},
+    head: {ref: head, sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+    labels: [],
+  }
+}
+
+pipeline test_pr_list_qualifies_bare_head_to_repository_owner(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://github-api.test"
+  http_mock(
+    "GET",
+    base
+      + "/repos/octo-org/octo-repo/pulls?state=open&head=octo-org%3Aautomation%2Fbump&base=main&per_page=10",
+    {
+      status: 200,
+      body: json_stringify([pull_fixture(7, "automation/bump")]),
+      headers: {"x-ratelimit-remaining": "10"},
+    },
+  )
+  const pulls = call(
+    "github.pr.list",
+    auth(base)
+      + {
+      repo: "octo-org/octo-repo",
+      filters: {state: "open", head: "automation/bump", base: "main", per_page: 10},
+    },
+  )
+  assert_eq(len(pulls), 1, "qualified head returns the intended PR")
+  assert_eq(pulls[0].head.ref, "automation/bump", "typed head remains branch-only")
+  assert_eq(len(http_mock_calls()), 1, "one exact REST request")
+}
+
+pipeline test_pr_list_preserves_explicit_fork_owner(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://github-api.test"
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/pulls?state=open&head=fork-user%3Afeature%2Fsafe",
+    {
+      status: 200,
+      body: json_stringify([pull_fixture(10, "feature/safe")]),
+      headers: {"x-ratelimit-remaining": "10"},
+    },
+  )
+  const pulls = call(
+    "github.pr.list",
+    auth(base)
+      + {repo: "octo-org/octo-repo", filters: {state: "open", head: "fork-user:feature/safe"}},
+  )
+  assert_eq(pulls.map({ pull -> pull.number }), [10], "explicit fork owner is preserved")
+  assert_eq(len(http_mock_calls()), 1, "one exact fork-owner request")
+}
+
+pipeline test_pr_list_merged_maps_to_closed_and_filters_unmerged_prs(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://github-api.test"
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/pulls?state=closed&base=main&per_page=30",
+    {
+      status: 200,
+      body: json_stringify(
+        [pull_fixture(8, "release/v1.0.0", "2026-07-13T00:00:00Z"), pull_fixture(9, "abandoned", nil)],
+      ),
+      headers: {"x-ratelimit-remaining": "10"},
+    },
+  )
+  const pulls = call(
+    "github.pr.list",
+    auth(base)
+      + {repo: "octo-org/octo-repo", filters: {state: "merged", base: "main", per_page: 30}},
+  )
+  assert_eq(pulls.map({ pull -> pull.number }), [8], "only actually merged PRs survive")
+  assert_eq(len(http_mock_calls()), 1, "merged state uses one closed-PR request")
+}
+
+pipeline test_pr_list_rejects_unsupported_state_before_network(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const result = call(
+    "github.pr.list",
+    auth("https://github-api.test") + {repo: "octo-org/octo-repo", filters: {state: "draft"}},
+  )
+  assert(is_err(result), "unsupported REST state fails closed")
+  assert_eq(unwrap_err(result).code, "schema_drift", "stable validation code")
+  assert_eq(len(http_mock_calls()), 0, "invalid state performs no network request")
+}
+
+pipeline test_graphql_promotes_protocol_errors(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://github-api.test"
+  http_mock(
+    "POST",
+    base + "/graphql",
+    {
+      status: 200,
+      body: json_stringify({data: nil, errors: [{type: "FORBIDDEN", message: "denied"}]}),
+      headers: {"x-ratelimit-remaining": "10"},
+    },
+  )
+  const result = call("graphql", auth(base) + {query: "query { viewer { login } }", variables: {}})
+  assert(is_err(result), "HTTP 200 GraphQL errors fail closed")
+  assert_eq(unwrap_err(result).code, "graphql", "stable GraphQL error code")
+  assert(contains(unwrap_err(result).message, "denied"), "provider message remains visible")
+}


### PR DESCRIPTION
Closes #157.

Fixes three release-safety contract defects found by adversarial HBF dogfood:
- owner-qualifies bare head branches while preserving explicit fork owners
- maps typed merged state to REST closed and filters unmerged closures; rejects unsupported states before network
- promotes GraphQL top-level errors on HTTP 200 to typed Err values

Exact URL fixtures cover owner qualification and REST state translation; mixed merged/unmerged fixtures prove fail-closed filtering.

Validation:
- harn fmt --check src tests
- harn check src
- harn lint src
- harn test tests/ (32/32)
- every tests/*.harn via harn run
- harn connector check . (16 fixtures)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-github-connector/pr/158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786511351&installation_id=145974243&pr_number=158&repository=burin-labs%2Fharn-github-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-github-connector%2Fpull%2F158&signature=3c56d42dd438d2301d5fca11e90d4d819e0d5334b1267b97ca6413fd5a1d648e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->