### PR TITLE
Preserve HTTP status in typed connector errors

### DIFF
--- a/src/lib.harn
+++ b/src/lib.harn
@@ -3454,8 +3454,15 @@ fn __set_state(state: GithubConnectorState) {
   return state
 }
 
-fn __err(code, message) {
-  return Err({code: code, category: __error_category(code), message: message})
+fn __err(code, message, details = nil) {
+  const error = {code: code, category: __error_category(code), message: message}
+  return Err(
+    if details == nil {
+      error
+    } else {
+      error + details
+    },
+  )
 }
 
 fn __error_category(code) {
@@ -6018,12 +6025,21 @@ fn __github_request_error(response) {
       return __err(
         "restricted_commit_author",
         "GitHub rejected the configured commit author/committer: " + message,
+        {http_status: response.status},
       )
     }
-    return __err("validation_failed", "GitHub API validation failed: " + message)
+    return __err(
+      "validation_failed",
+      "GitHub API validation failed: " + message,
+      {http_status: response.status},
+    )
   }
   const code = __github_error_code(response)
-  return __err(code, "github API request failed with status " + to_string(response.status))
+  return __err(
+    code,
+    "github API request failed with status " + to_string(response.status),
+    {http_status: response.status},
+  )
 }
 
 fn __github_error_code(response) {

--- a/tests/release_view.harn
+++ b/tests/release_view.harn
@@ -74,4 +74,17 @@ pipeline test_release_view_provider_error(task) {
   assert_eq(missing.ok, false, "provider failure remains typed")
   assert_eq(missing.repo, "octo-org/octo-repo", "error keeps repo identity")
   assert(missing.error != nil, "provider error is retained")
+  assert_eq(missing.error.http_status, 404, "provider error retains structured HTTP status")
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/releases/tags/v9.9.8",
+    {
+      status: 403,
+      body: json_stringify({message: "Resource not accessible by integration"}),
+      headers: {"x-ratelimit-remaining": "10"},
+    },
+  )
+  const forbidden = github_release("octo-org", "octo-repo", "v9.9.8", auth)
+  assert_eq(forbidden.ok, false, "permission failure remains typed")
+  assert_eq(forbidden.error.http_status, 403, "non-404 provider status is retained")
 }


### PR DESCRIPTION
## Summary
- retain `http_status` on typed errors produced from GitHub HTTP responses
- preserve existing error code/category/message contracts
- cover both exact-resource 404 and permission 403 responses

This lets orchestration distinguish confirmed resource absence from provider uncertainty without parsing prose.

## Verification
- `harn check src`
- `harn lint src`
- `harn fmt --check src tests`
- all 24 test programs
- `harn connector check .` (16 fixtures)

Closes #159

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-github-connector/pr/160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786512650&installation_id=145974243&pr_number=160&repository=burin-labs%2Fharn-github-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-github-connector%2Fpull%2F160&signature=c950bdb7a8dd2cbb5f3409042193a38981c44a174d84dee1f01da84bbb487294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->