### PR TITLE
Add typed workflow-run jobs access

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Call methods through `call(method, args)` unless a named helper fits better.
 | Area | Methods |
 |---|---|
 | Pull requests | `github.pr.list`, `github.pr.view`, `github.pr.edit`, `github.pr.checks`, `github.pr.merge`, `github.pr.enable_auto_merge`, `github.pr.comment`, `pulls.list`, `pulls.list_with_checks`, `pulls.get`, `pulls.update`, `pulls.create`, `pulls.merge`, `pulls.merge_safe`, `pulls.create_review_comment`, `pulls.get_diff`, `pulls.list_files`, `pulls.list_reviews`, `pull_requests.resolve_mergeable`, `repos.commit_pulls` |
-| Actions and checks | `github.actions.workflow_dispatch`, `github.actions.runs`, `github.actions.run`, `github.actions.logs`, `actions.workflow_dispatch`, `actions.workflow_runs.list`, `actions.workflow_run.get`, `check_runs.create`, `check_runs.update` |
+| Actions and checks | `github.actions.workflow_dispatch`, `github.actions.runs`, `github.actions.run`, `github.actions.logs`, `actions.workflow_dispatch`, `actions.workflow_runs.list`, `actions.workflow_run.get`, `actions.workflow_run.jobs`, `check_runs.create`, `check_runs.update` |
 | Self-hosted runners | `actions.runners.registration_token`, `actions.runners.remove_token`, `actions.runners.generate_jitconfig`, `actions.runners.list`, `actions.runners.get`, `actions.runners.delete`, `actions.runners.downloads`, `actions.runners.labels.list`, `actions.runners.labels.add`, `actions.runners.labels.replace`, `actions.runners.labels.remove`, `actions.runner_groups.list`, `actions.runner_groups.create`, `actions.runner_groups.get`, `actions.runner_groups.update`, `actions.runner_groups.delete` |
 | User OAuth | `oauth.user.device_code`, `oauth.user.device_poll`, `oauth.user.exchange_code`, `oauth.user.refresh` |
 | Issues | `github.issue.create`, `github.issue.comment`, `issues.create_comment`, `issues.create`, `issues.create_with_template`, `issues.update`, `issues.add_labels` |
@@ -151,6 +151,7 @@ Named helpers:
 | `pulls_enable_auto_merge(owner, repo, number, options)` | Enable GitHub auto-merge. |
 | `actions_workflow_dispatch(owner, repo, workflow_id, ref, inputs, options)` | Dispatch a workflow. |
 | `actions_workflow_runs(owner, repo, options)` | List workflow runs. |
+| `actions_workflow_run_jobs(owner, repo, run_id, options)` | List a workflow run's jobs and steps; options support `filter`, `per_page`, and `page`. |
 | `api_call(path, method, body, options)` | Call one REST endpoint. Prefer typed helpers when available. |
 | `repos_get_text(owner, repo, path, ref, options)` | Decode repository file content as UTF-8 text. |
 | `repos_get_latest_release(owner, repo, options)` | Fetch latest release metadata. |

--- a/changelog.d/actions-run-jobs.added.md
+++ b/changelog.d/actions-run-jobs.added.md
@@ -1,0 +1,3 @@
+Added a typed workflow-run jobs API that returns GitHub's canonical jobs and
+steps payload, validates run identifiers, and supports bounded filter and
+pagination options.

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -65,6 +65,7 @@ const GITHUB_OUTBOUND_METHODS = [
   "actions.workflow_dispatch",
   "actions.workflow_runs.list",
   "actions.workflow_run.get",
+  "actions.workflow_run.jobs",
   "actions.runners.registration_token",
   "actions.runners.remove_token",
   "actions.runners.generate_jitconfig",
@@ -600,6 +601,9 @@ pub fn call(method, args = {}) {
   if method == "actions.workflow_run.get" {
     return __actions_workflow_run_get(args, cfg)
   }
+  if method == "actions.workflow_run.jobs" {
+    return __actions_workflow_run_jobs(args, cfg)
+  }
   if starts_with(method, "actions.runners.") || starts_with(method, "actions.runner_groups.") {
     return __actions_runners_dispatch(method, args, cfg)
   }
@@ -716,6 +720,12 @@ pub fn actions_workflow_dispatch(
 pub fn actions_workflow_runs(owner, repo, options = nil) {
   const opts = options ?? {}
   return call("actions.workflow_runs.list", opts + {owner: owner, repo: repo})
+}
+
+/** List the jobs and steps for one workflow run. */
+pub fn actions_workflow_run_jobs(owner, repo, run_id, options = nil) {
+  const opts = options ?? {}
+  return call("actions.workflow_run.jobs", opts + {owner: owner, repo: repo, run_id: run_id})
 }
 
 /**
@@ -2359,9 +2369,9 @@ fn __actions_workflow_runs_list(args, cfg) {
 }
 
 fn __actions_workflow_run_get(args, cfg) {
-  const run_id = args?.run_id ?? args?.id
-  if run_id == nil || trim(to_string(run_id)) == "" {
-    return __err("schema_drift", "actions.workflow_run.get requires run_id or id")
+  const run_id = __actions_run_id(args?.run_id ?? args?.id)
+  if run_id == nil {
+    return __err("schema_drift", "actions.workflow_run.get requires a positive decimal run_id or id")
   }
   return __github_json(
     "GET",
@@ -2372,6 +2382,49 @@ fn __actions_workflow_run_get(args, cfg) {
     nil,
     cfg,
   )
+}
+
+fn __actions_workflow_run_jobs(args, cfg) {
+  const run_id = __actions_run_id(args?.run_id)
+  if run_id == nil {
+    return __err("schema_drift", "actions.workflow_run.jobs requires a positive decimal run_id")
+  }
+  const filter = trim(to_string(args?.filter ?? ""))
+  if filter != "" && filter != "latest" && filter != "all" {
+    return __err("schema_drift", "actions.workflow_run.jobs filter must be latest or all")
+  }
+  if args?.per_page != nil && __positive_decimal(args.per_page, 100) == nil {
+    return __err("schema_drift", "actions.workflow_run.jobs per_page must be an integer from 1 to 100")
+  }
+  if args?.page != nil && __positive_decimal(args.page, nil) == nil {
+    return __err("schema_drift", "actions.workflow_run.jobs page must be a positive integer")
+  }
+  return __github_json(
+    "GET",
+    __github_api_url(
+      cfg.api_base_url,
+      "/repos/" + args.owner + "/" + args.repo + "/actions/runs/" + to_string(run_id) + "/jobs"
+        + __workflow_run_jobs_query(args),
+    ),
+    nil,
+    cfg,
+  )
+}
+
+fn __actions_run_id(value) {
+  const raw = trim(to_string(value ?? ""))
+  if len(regex_captures("^[1-9][0-9]*$", raw)) == 0 {
+    return nil
+  }
+  return to_int(raw)
+}
+
+fn __positive_decimal(value, max_value) {
+  const parsed = __actions_run_id(value)
+  if parsed == nil || (max_value != nil && parsed > max_value) {
+    return nil
+  }
+  return parsed
 }
 
 /**
@@ -5477,6 +5530,21 @@ fn __pagination_query(args) {
 fn __workflow_runs_query(args) {
   let parts = []
   const keys = ["actor", "branch", "event", "status", "created", "check_suite_id", "head_sha", "per_page", "page"]
+  for key in keys {
+    const value = args.get(key)
+    if value != nil {
+      parts = parts + [key + "=" + url_encode(to_string(value))]
+    }
+  }
+  if len(parts) == 0 {
+    return ""
+  }
+  return "?" + join(parts, "&")
+}
+
+fn __workflow_run_jobs_query(args) {
+  let parts = []
+  const keys = ["filter", "per_page", "page"]
   for key in keys {
     const value = args.get(key)
     if value != nil {

--- a/tests/actions_workflow_run_jobs.harn
+++ b/tests/actions_workflow_run_jobs.harn
@@ -1,0 +1,107 @@
+import { actions_workflow_run_jobs, call } from "../src/lib"
+
+fn auth(base) {
+  return {api_base_url: base, installation_token: "test-token"}
+}
+
+fn jobs_fixture(harness: Harness) {
+  return json_parse(harness.fs.read_text(source_dir() + "/fixtures/actions_workflow_run_jobs.json"))
+}
+
+pipeline test_actions_workflow_run_jobs_returns_canonical_payload(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://github-api.test"
+  const fixture = jobs_fixture(harness)
+  const url = base
+    + "/repos/octo-org/octo-repo/actions/runs/29679449/jobs?filter=all&per_page=25&page=2"
+  http_mock(
+    "GET",
+    url,
+    {status: 200, body: json_stringify(fixture), headers: {"x-ratelimit-remaining": "10"}},
+  )
+  const result = actions_workflow_run_jobs(
+    "octo-org",
+    "octo-repo",
+    29679449,
+    auth(base) + {filter: "all", per_page: 25, page: 2},
+  )
+  assert_eq(result, fixture, "GitHub jobs payload is returned unchanged")
+  assert_eq(result.jobs[0].run_id, 29679449, "job retains workflow run id")
+  assert_eq(result.jobs[0].steps[1].name, "Run tests", "job retains canonical nested steps")
+  assert_eq(result.jobs[0].steps[1].conclusion, "success", "step conclusion is retained")
+  const calls = http_mock_calls()
+  assert_eq(len(calls), 1, "one exact REST request")
+  assert_eq(calls[0].method, "GET", "workflow jobs uses GET")
+  assert_eq(calls[0].url, url, "workflow jobs forwards filter and pagination options")
+}
+
+pipeline test_actions_workflow_run_jobs_requires_run_id(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://github-api.test"
+  const missing = call("actions.workflow_run.jobs", auth(base) + {owner: "octo-org", repo: "octo-repo"})
+  assert(is_err(missing), "missing run_id fails closed")
+  assert_eq(
+    unwrap_err(missing),
+    {
+      code: "schema_drift",
+      category: "schema_drift",
+      message: "actions.workflow_run.jobs requires a positive decimal run_id",
+    },
+    "missing run_id returns the exact typed validation error",
+  )
+  const blank = actions_workflow_run_jobs("octo-org", "octo-repo", "   ", auth(base))
+  assert(is_err(blank), "blank run_id fails closed")
+  assert_eq(unwrap_err(blank).code, "schema_drift", "blank run_id uses the validation code")
+  const path_escape = actions_workflow_run_jobs("octo-org", "octo-repo", "1/jobs/../2", auth(base))
+  assert(is_err(path_escape), "path-bearing run id fails closed")
+  assert_eq(unwrap_err(path_escape).code, "schema_drift", "path-bearing run id uses validation code")
+  assert_eq(len(http_mock_calls()), 0, "invalid run ids perform no network requests")
+}
+
+pipeline test_actions_workflow_run_jobs_validates_query_options(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://github-api.test"
+  const bad_filter = actions_workflow_run_jobs("octo-org", "octo-repo", 29679449, auth(base) + {filter: "recent"})
+  assert(is_err(bad_filter), "unknown job filter fails closed")
+  assert_eq(
+    unwrap_err(bad_filter).message,
+    "actions.workflow_run.jobs filter must be latest or all",
+    "filter error names the closed option set",
+  )
+  const oversized_page = actions_workflow_run_jobs("octo-org", "octo-repo", 29679449, auth(base) + {per_page: 101})
+  assert(is_err(oversized_page), "oversized page fails closed")
+  const zero_page = actions_workflow_run_jobs("octo-org", "octo-repo", 29679449, auth(base) + {page: 0})
+  assert(is_err(zero_page), "zero page fails closed")
+  assert_eq(len(http_mock_calls()), 0, "invalid query options perform no network requests")
+}
+
+pipeline test_actions_workflow_run_jobs_preserves_http_failure(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://github-api.test"
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/actions/runs/29679449/jobs",
+    {
+      status: 403,
+      body: json_stringify({message: "Resource not accessible by integration"}),
+      headers: {"x-ratelimit-remaining": "10"},
+    },
+  )
+  const result = actions_workflow_run_jobs("octo-org", "octo-repo", 29679449, auth(base))
+  assert(is_err(result), "GitHub HTTP failure remains typed")
+  assert_eq(
+    unwrap_err(result),
+    {
+      code: "missing_scopes",
+      category: "permission",
+      message: "github API request failed with status 403",
+      http_status: 403,
+    },
+    "HTTP failure preserves the exact connector error shape and status",
+  )
+  assert_eq(len(http_mock_calls()), 1, "HTTP failure performs one request")
+}

--- a/tests/fixtures/actions_workflow_run_jobs.json
+++ b/tests/fixtures/actions_workflow_run_jobs.json
@@ -1,0 +1,45 @@
+{
+  "total_count": 1,
+  "jobs": [
+    {
+      "id": 399444496,
+      "run_id": 29679449,
+      "run_url": "https://api.github.com/repos/octo-org/octo-repo/actions/runs/29679449",
+      "node_id": "MDEyOldvcmtmbG93IEpvYjM5OTQ0NDQ5Ng==",
+      "head_sha": "f83a356604ae3c5d03e1b46ef4d1ca77d64a90b0",
+      "url": "https://api.github.com/repos/octo-org/octo-repo/actions/jobs/399444496",
+      "html_url": "https://github.com/octo-org/octo-repo/runs/29679449/jobs/399444496",
+      "status": "completed",
+      "conclusion": "success",
+      "started_at": "2020-01-20T17:42:40Z",
+      "completed_at": "2020-01-20T17:44:39Z",
+      "name": "build",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1,
+          "started_at": "2020-01-20T09:42:40.000-08:00",
+          "completed_at": "2020-01-20T09:42:41.000-08:00"
+        },
+        {
+          "name": "Run tests",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2,
+          "started_at": "2020-01-20T09:42:41.000-08:00",
+          "completed_at": "2020-01-20T09:44:39.000-08:00"
+        }
+      ],
+      "check_run_url": "https://api.github.com/repos/octo-org/octo-repo/check-runs/399444496",
+      "labels": ["self-hosted", "linux"],
+      "runner_id": 1,
+      "runner_name": "release-runner",
+      "runner_group_id": 2,
+      "runner_group_name": "release-runners",
+      "workflow_name": "Release",
+      "head_branch": "main"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `actions.workflow_run.jobs` and `actions_workflow_run_jobs(...)` for canonical GitHub job/step payloads
- support the documented `filter`, `per_page`, and `page` query options
- reject non-decimal/path-bearing run identifiers and invalid query values before network access
- preserve typed connector HTTP failures, including `http_status`

This supplies the owning connector primitive for burin-labs/harn-bump-fleet#279 so release gates can prove that a required job and step actually ran without parsing `gh run view` output.

## Verification
- `harn check src`
- `harn lint src`
- `harn fmt --check src tests`
- `harn test tests/ --verbose`: 36/36
- `harn connector check .`: 1 connector, 16 fixtures
- `harn connector test . --json`: 8/8 stages
- signed commit `b9ee7e6e02c59179a3ccf8f41091cf30eb215c1c`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-github-connector/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786524213&installation_id=145974243&pr_number=161&repository=burin-labs%2Fharn-github-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-github-connector%2Fpull%2F161&signature=bff85058e1b546365da09aaae1a30088522de2cf5c2221217938292641b7934b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->