### PR TITLE
Fix workflow dispatch run identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Named helpers:
 | `github_latest_release(owner, repo, options)` | Fetch latest release metadata in a stable envelope. |
 | `github_release_assets(owner, repo, release_id, options)` | List release assets in a stable envelope; defaults to the latest release. |
 | `issues_create_with_template(owner, repo, template, vars, options)` | Render a small title/body template, then create an issue. |
-| `github_dispatch_workflow_and_wait(owner, repo, workflow_id, ref, inputs, options)` | Dispatch a workflow and wait for completion. |
+| `github_dispatch_workflow_and_wait(owner, repo, workflow_id, ref, inputs, options)` | Dispatch a workflow and wait for its exact run, rejecting ambiguous unseen matches. |
 | `github_wait_for_workflow_run(owner, repo, run_id_or_filter, options)` | Poll an existing workflow run or a filtered run lookup. |
 | `github_ensure_auto_merge(owner, repo, pull_number, options)` | Enable auto-merge and normalize already-enabled responses. |
 | `github_wait_for_pr_checks(owner, repo, pull_number_or_ref, options)` | Wait for visible PR or commit checks; optionally attach failing Actions log tails. |

--- a/changelog.d/162.fixed.md
+++ b/changelog.d/162.fixed.md
@@ -1,0 +1,3 @@
+Workflow dispatch waits now snapshot matching run IDs before dispatch, select
+only one unseen exact run when GitHub returns no ID, and fail closed with a
+typed `ambiguous_dispatch` result when multiple unseen runs match.

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -886,10 +886,10 @@ const DEFAULT_LOG_TAIL_LINES = 200
 
 /**
  * Dispatch a workflow_dispatch workflow and wait for it to finish. Returns a
- * stable `{ok, status, conclusion, run_id, run_url, workflow_id, created_at,
- * started_at, updated_at, attempts, timed_out, error}` envelope. `status` is
- * one of `completed`, `timed_out`, `dispatch_failed`, `run_not_found`, or
- * `poll_failed`.
+ * stable `{ok, status, conclusion, run_id, candidate_run_ids, run_url,
+ * workflow_id, created_at, started_at, updated_at, attempts, timed_out, error}`
+ * envelope. `status` is one of `completed`, `timed_out`, `dispatch_failed`,
+ * `ambiguous_dispatch`, `run_not_found`, or `poll_failed`.
  */
 pub fn github_dispatch_workflow_and_wait(
   owner,
@@ -901,7 +901,26 @@ pub fn github_dispatch_workflow_and_wait(
 ) {
   const opts = options ?? {}
   const auth = __auth_options(opts)
-  const dispatched_at_iso = opts?.created_after ?? date_now_iso()
+  const filter = {
+    workflow_id: workflow_id,
+    event: opts?.event ?? "workflow_dispatch",
+    branch: opts?.branch ?? ref,
+    head_sha: opts?.head_sha,
+    per_page: opts?.per_page ?? 10,
+  }
+  const snapshot = __exact_workflow_runs(owner, repo, filter, auth)
+  if is_err(snapshot) {
+    return __workflow_wait_envelope(
+      false,
+      "poll_failed",
+      workflow_id,
+      nil,
+      [{attempt: 0, kind: "snapshot_failed", error: unwrap_err(snapshot)}],
+      false,
+      unwrap_err(snapshot),
+    )
+  }
+  const snapshot_run_ids = __workflow_run_ids(snapshot)
   const dispatch = actions_workflow_dispatch(owner, repo, workflow_id, ref, inputs ?? {}, auth)
   if is_err(dispatch) {
     return __workflow_wait_envelope(
@@ -915,16 +934,9 @@ pub fn github_dispatch_workflow_and_wait(
     )
   }
   const dispatch_run_id = __extract_dispatch_run_id(dispatch)
-  const filter = {
-    workflow_id: workflow_id,
-    event: opts?.event ?? "workflow_dispatch",
-    branch: opts?.branch ?? ref,
-    head_sha: opts?.head_sha,
-    per_page: opts?.per_page ?? 10,
-    created_after: dispatched_at_iso,
-  }
-  const wait_options = opts + {workflow_id: workflow_id, filter: filter}
-  const target = dispatch_run_id ?? filter
+  const dispatch_filter = filter + {excluded_run_ids: snapshot_run_ids, require_unambiguous_dispatch: true}
+  const wait_options = opts + {workflow_id: workflow_id, filter: dispatch_filter}
+  const target = dispatch_run_id ?? dispatch_filter
   return github_wait_for_workflow_run(owner, repo, target, wait_options)
 }
 
@@ -1051,6 +1063,18 @@ fn __workflow_wait_loop(owner, repo, cfg) {
     if run_id == nil {
       const located = __workflow_wait_locate_step(owner, repo, cfg.filter, cfg.auth, attempt)
       attempts = attempts + located.attempts
+      if len(located?.candidate_run_ids ?? []) > 1 {
+        return __workflow_wait_envelope(
+          false,
+          "ambiguous_dispatch",
+          cfg.workflow_id,
+          nil,
+          attempts,
+          false,
+          located.error,
+          located.candidate_run_ids,
+        )
+      }
       run_id = located.run_id
     }
     if run_id != nil {
@@ -1081,6 +1105,9 @@ fn __workflow_wait_loop_terminal(cfg, attempts, run_id, last_run) {
 }
 
 fn __workflow_wait_locate_step(owner, repo, filter, auth, attempt) {
+  if filter?.require_unambiguous_dispatch ?? false {
+    return __workflow_wait_locate_dispatch_step(owner, repo, filter, auth, attempt)
+  }
   const located = __locate_workflow_run(owner, repo, filter, auth)
   if is_err(located) {
     return {attempts: [{attempt: attempt, kind: "list_failed", error: unwrap_err(located)}], run_id: nil}
@@ -1091,6 +1118,43 @@ fn __workflow_wait_locate_step(owner, repo, filter, auth, attempt) {
   return {
     attempts: [{attempt: attempt, kind: "located", run_id: located.id, created_at: located?.created_at}],
     run_id: located.id,
+  }
+}
+
+fn __workflow_wait_locate_dispatch_step(owner, repo, filter, auth, attempt) {
+  const located = __exact_workflow_runs(owner, repo, filter, auth)
+  if is_err(located) {
+    return {attempts: [{attempt: attempt, kind: "list_failed", error: unwrap_err(located)}], run_id: nil}
+  }
+  let unseen = []
+  for run in located {
+    if !(filter?.excluded_run_ids ?? []).contains(run.id) {
+      unseen = unseen + [run]
+    }
+  }
+  const run_ids = __workflow_run_ids(unseen)
+  if len(run_ids) == 0 {
+    return {attempts: [{attempt: attempt, kind: "run_not_found"}], run_id: nil}
+  }
+  if len(run_ids) > 1 {
+    const error = unwrap_err(
+      __err(
+        "ambiguous_dispatch",
+        "multiple unseen workflow runs matched the dispatch",
+        {candidate_run_ids: run_ids},
+      ),
+    )
+    return {
+      attempts: [{attempt: attempt, kind: "ambiguous_dispatch", candidate_run_ids: run_ids}],
+      run_id: nil,
+      candidate_run_ids: run_ids,
+      error: error,
+    }
+  }
+  return {
+    attempts: [{attempt: attempt, kind: "located", run_id: run_ids[0], created_at: unseen[0]?.created_at}],
+    run_id: run_ids[0],
+    candidate_run_ids: run_ids,
   }
 }
 
@@ -1360,6 +1424,46 @@ fn __locate_workflow_run(owner, repo, filter, auth) {
   return __pick_newest_run(resp?.workflow_runs ?? [], filter)
 }
 
+fn __exact_workflow_runs(owner, repo, filter, auth) {
+  const resp = actions_workflow_runs(owner, repo, auth + __locate_args(filter))
+  if is_err(resp) {
+    return resp
+  }
+  let matches = []
+  for run in resp?.workflow_runs ?? [] {
+    if __run_matches_exact_dispatch_filter(run, filter) {
+      matches = matches + [run]
+    }
+  }
+  return matches
+}
+
+fn __run_matches_exact_dispatch_filter(run, filter) {
+  if run?.id == nil {
+    return false
+  }
+  if filter?.event != nil && run?.event != filter.event {
+    return false
+  }
+  if filter?.branch != nil && run?.head_branch != filter.branch {
+    return false
+  }
+  if filter?.head_sha != nil && run?.head_sha != filter.head_sha {
+    return false
+  }
+  return true
+}
+
+fn __workflow_run_ids(runs) {
+  let ids = []
+  for run in runs {
+    if run?.id != nil && !ids.contains(run.id) {
+      ids = ids + [run.id]
+    }
+  }
+  return ids
+}
+
 fn __locate_args(filter) {
   let args = {}
   if filter?.workflow_id != nil {
@@ -1414,12 +1518,26 @@ fn __run_is_newer(candidate, best) {
   return to_string(created_at) > to_string(best.created_at)
 }
 
-fn __workflow_wait_envelope(ok, status, workflow_id, run_id, attempts, timed_out, error) {
+fn __workflow_wait_envelope(
+  ok,
+  status,
+  workflow_id,
+  run_id,
+  attempts,
+  timed_out,
+  error,
+  candidate_run_ids = nil,
+) {
   return {
     ok: ok,
     status: status,
     conclusion: nil,
     run_id: run_id,
+    candidate_run_ids: candidate_run_ids ?? if run_id == nil {
+      []
+    } else {
+      [run_id]
+    },
     run_url: nil,
     workflow_id: workflow_id,
     created_at: nil,
@@ -1437,6 +1555,11 @@ fn __workflow_envelope_from_run(ok, status, run, attempts, timed_out, error) {
     status: status,
     conclusion: run?.conclusion,
     run_id: run?.id,
+    candidate_run_ids: if run?.id == nil {
+      []
+    } else {
+      [run.id]
+    },
     run_url: run?.html_url ?? run?.url,
     workflow_id: run?.workflow_id,
     created_at: run?.created_at,

--- a/tests/orchestration_helpers.harn
+++ b/tests/orchestration_helpers.harn
@@ -42,6 +42,21 @@ fn dispatch_204() {
 pipeline test_dispatch_with_run_id_completes_success(task) {
   egress_policy({allow: ["github-api.test", "api.github.test"], default: "deny"})
   http_mock_clear()
+  const runs_url = BASE
+    + "/repos/octo-org/octo-repo/actions/workflows/bump-harn.yml/runs?branch=main&event=workflow_dispatch&per_page=10"
+  http_mock(
+    "GET",
+    runs_url,
+    {
+      responses: [
+        {
+          status: 200,
+          body: json_stringify({total_count: 0, workflow_runs: []}),
+          headers: {"x-ratelimit-remaining": "31"},
+        },
+      ],
+    },
+  )
   http_mock(
     "POST",
     BASE + "/repos/octo-org/octo-repo/actions/workflows/bump-harn.yml/dispatches",
@@ -81,12 +96,63 @@ pipeline test_dispatch_with_run_id_completes_success(task) {
   assert(result.run_url.contains("/actions/runs/123"), "run url")
   assert_eq(result.timed_out, false, "not timed out")
   assert(len(result.attempts) >= 2, "polled at least twice")
+  assert_eq(result.candidate_run_ids, [123], "returned run id is the only candidate")
+  const calls = http_mock_calls()
+  assert_eq(len(calls), 4, "snapshot, dispatch, and two direct run probes")
+  assert_eq(calls[0].url, runs_url, "matching ids are snapshotted before dispatch")
+  assert_eq(calls[1].method, "POST", "dispatch follows the snapshot")
+  assert_eq(
+    calls[2].url,
+    BASE + "/repos/octo-org/octo-repo/actions/runs/123",
+    "returned id is the fast path",
+  )
+  assert_eq(
+    calls[3].url,
+    BASE + "/repos/octo-org/octo-repo/actions/runs/123",
+    "returned id stays pinned",
+  )
   http_mock_clear()
 }
 
-pipeline test_dispatch_locates_run_when_no_id_returned(task) {
+pipeline test_dispatch_selects_only_unseen_exact_run(task) {
   egress_policy({allow: ["github-api.test", "api.github.test"], default: "deny"})
   http_mock_clear()
+  const sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+  const runs_url = BASE
+    + "/repos/octo-org/octo-repo/actions/workflows/release.yml/runs?branch=main&event=workflow_dispatch&head_sha="
+    + sha
+    + "&per_page=10"
+  http_mock(
+    "GET",
+    runs_url,
+    {
+      responses: [
+        {
+          status: 200,
+          body: json_stringify(
+            {total_count: 1, workflow_runs: [run_payload(900, "completed", "success", "2035-01-01T00:00:00Z")]},
+          ),
+          headers: {"x-ratelimit-remaining": "21"},
+        },
+        {
+          status: 200,
+          body: json_stringify(
+            {
+              total_count: 5,
+              workflow_runs: [
+                run_payload(900, "completed", "success", "2035-01-01T00:00:00Z"),
+                run_payload(901, "in_progress", nil, "not-a-timestamp"),
+                run_payload(902, "queued") + {event: "push"},
+                run_payload(903, "queued") + {head_branch: "other"},
+                run_payload(904, "queued") + {head_sha: "cafebabecafebabecafebabecafebabecafebabe"},
+              ],
+            },
+          ),
+          headers: {"x-ratelimit-remaining": "19"},
+        },
+      ],
+    },
+  )
   http_mock(
     "POST",
     BASE + "/repos/octo-org/octo-repo/actions/workflows/release.yml/dispatches",
@@ -94,38 +160,11 @@ pipeline test_dispatch_locates_run_when_no_id_returned(task) {
   )
   http_mock(
     "GET",
-    BASE
-      + "/repos/octo-org/octo-repo/actions/workflows/release.yml/runs?branch=main&event=workflow_dispatch&per_page=10",
-    {
-      responses: [
-        {
-          status: 200,
-          body: json_stringify({total_count: 0, workflow_runs: []}),
-          headers: {"x-ratelimit-remaining": "19"},
-        },
-        {
-          status: 200,
-          body: json_stringify(
-            {
-              total_count: 2,
-              workflow_runs: [
-                run_payload(900, "in_progress", nil, "2025-01-01T00:00:00Z"),
-                run_payload(901, "in_progress", nil, "2030-01-01T00:00:00Z"),
-              ],
-            },
-          ),
-          headers: {"x-ratelimit-remaining": "18"},
-        },
-      ],
-    },
-  )
-  http_mock(
-    "GET",
     BASE + "/repos/octo-org/octo-repo/actions/runs/901",
     {
       status: 200,
-      body: json_stringify(run_payload(901, "completed", "failure", "2030-01-01T00:00:00Z")),
-      headers: {"x-ratelimit-remaining": "17"},
+      body: json_stringify(run_payload(901, "completed", "failure", "not-a-timestamp")),
+      headers: {"x-ratelimit-remaining": "18"},
     },
   )
   const result = github_dispatch_workflow_and_wait(
@@ -134,32 +173,95 @@ pipeline test_dispatch_locates_run_when_no_id_returned(task) {
     "release.yml",
     "main",
     nil,
-    auth() + {created_after: "2026-01-01T00:00:00Z"},
+    auth() + {head_sha: sha},
   )
   assert_eq(result.status, "completed", "status completed even on failing conclusion")
   assert_eq(result.ok, true, "ok=true when wait completes")
   assert_eq(result.conclusion, "failure", "failure conclusion surfaces")
-  assert_eq(result.run_id, 901, "newest matching run after cutoff")
+  assert_eq(result.run_id, 901, "only unseen exact run selected")
+  assert_eq(result.candidate_run_ids, [901], "selected identity is structured")
+  const calls = http_mock_calls()
+  assert_eq(calls[0].url, runs_url, "pre-dispatch exact ids snapshotted")
+  assert_eq(calls[1].method, "POST", "dispatch occurs after snapshot")
+  assert_eq(calls[2].url, runs_url, "same exact filter locates unseen runs")
+  assert_eq(
+    calls[3].url,
+    BASE + "/repos/octo-org/octo-repo/actions/runs/901",
+    "selected id is pinned",
+  )
+  http_mock_clear()
+}
+
+pipeline test_dispatch_rejects_multiple_unseen_exact_runs(task) {
+  egress_policy({allow: ["github-api.test", "api.github.test"], default: "deny"})
+  http_mock_clear()
+  const runs_url = BASE
+    + "/repos/octo-org/octo-repo/actions/workflows/ambiguous.yml/runs?branch=main&event=workflow_dispatch&per_page=10"
+  http_mock(
+    "GET",
+    runs_url,
+    {
+      responses: [
+        {
+          status: 200,
+          body: json_stringify({total_count: 1, workflow_runs: [run_payload(800, "completed", "success")]}),
+          headers: {"x-ratelimit-remaining": "12"},
+        },
+        {
+          status: 200,
+          body: json_stringify(
+            {
+              total_count: 3,
+              workflow_runs: [
+                run_payload(800, "completed", "success"),
+                run_payload(801, "queued", nil, "2020-01-01T00:00:00Z"),
+                run_payload(802, "queued", nil, "2030-01-01T00:00:00Z"),
+              ],
+            },
+          ),
+          headers: {"x-ratelimit-remaining": "10"},
+        },
+      ],
+    },
+  )
+  http_mock(
+    "POST",
+    BASE + "/repos/octo-org/octo-repo/actions/workflows/ambiguous.yml/dispatches",
+    {status: 204, body: dispatch_204(), headers: {"x-ratelimit-remaining": "11"}},
+  )
+  const result = github_dispatch_workflow_and_wait("octo-org", "octo-repo", "ambiguous.yml", "main", nil, auth())
+  assert_eq(result.ok, false, "ambiguous dispatch fails closed")
+  assert_eq(result.status, "ambiguous_dispatch", "typed ambiguous status")
+  assert_eq(result.run_id, nil, "no ambiguous run is pinned")
+  assert_eq(result.candidate_run_ids, [801, 802], "all unseen exact identities surface")
+  assert_eq(result.error.code, "ambiguous_dispatch", "typed ambiguous error")
+  assert_eq(result.error.candidate_run_ids, [801, 802], "error carries candidate identities")
+  assert_eq(result.timed_out, false, "ambiguity terminates immediately")
+  assert_eq(len(http_mock_calls()), 3, "no ambiguous run is probed")
   http_mock_clear()
 }
 
 pipeline test_dispatch_times_out_when_run_never_appears(task) {
   egress_policy({allow: ["github-api.test", "api.github.test"], default: "deny"})
   http_mock_clear()
+  const runs_url = BASE
+    + "/repos/octo-org/octo-repo/actions/workflows/never.yml/runs?branch=main&event=workflow_dispatch&per_page=10"
+  http_mock(
+    "GET",
+    runs_url,
+    {
+      responses: [
+        {status: 200, body: json_stringify({total_count: 0, workflow_runs: []})},
+        {status: 200, body: json_stringify({total_count: 0, workflow_runs: []})},
+        {status: 200, body: json_stringify({total_count: 0, workflow_runs: []})},
+        {status: 200, body: json_stringify({total_count: 0, workflow_runs: []})},
+      ],
+    },
+  )
   http_mock(
     "POST",
     BASE + "/repos/octo-org/octo-repo/actions/workflows/never.yml/dispatches",
     {status: 204, body: "", headers: {"x-ratelimit-remaining": "10"}},
-  )
-  http_mock(
-    "GET",
-    BASE
-      + "/repos/octo-org/octo-repo/actions/workflows/never.yml/runs?branch=main&event=workflow_dispatch&per_page=10",
-    {
-      status: 200,
-      body: json_stringify({total_count: 0, workflow_runs: []}),
-      headers: {"x-ratelimit-remaining": "9"},
-    },
   )
   const result = github_dispatch_workflow_and_wait(
     "octo-org",
@@ -167,18 +269,29 @@ pipeline test_dispatch_times_out_when_run_never_appears(task) {
     "never.yml",
     "main",
     nil,
-    auth() + {max_attempts: 3, created_after: "2026-01-01T00:00:00Z"},
+    auth() + {max_attempts: 3},
   )
   assert_eq(result.ok, false, "ok=false when never found")
   assert_eq(result.status, "run_not_found", "status=run_not_found")
   assert_eq(result.timed_out, true, "timed_out=true")
   assert_eq(result.run_id, nil, "run_id=nil")
+  assert_eq(
+    len(http_mock_calls()),
+    5,
+    "one snapshot, one dispatch, and three bounded lookup attempts",
+  )
   http_mock_clear()
 }
 
 pipeline test_dispatch_returns_dispatch_failed(task) {
   egress_policy({allow: ["github-api.test", "api.github.test"], default: "deny"})
   http_mock_clear()
+  http_mock(
+    "GET",
+    BASE
+      + "/repos/octo-org/octo-repo/actions/workflows/broken.yml/runs?branch=main&event=workflow_dispatch&per_page=10",
+    {responses: [{status: 200, body: json_stringify({total_count: 0, workflow_runs: []})}]},
+  )
   http_mock(
     "POST",
     BASE + "/repos/octo-org/octo-repo/actions/workflows/broken.yml/dispatches",
@@ -192,6 +305,33 @@ pipeline test_dispatch_returns_dispatch_failed(task) {
   assert_eq(result.ok, false, "ok=false")
   assert_eq(result.status, "dispatch_failed", "status=dispatch_failed")
   assert(result.error != nil, "error captured")
+  assert_eq(len(http_mock_calls()), 2, "snapshot does not obscure the dispatch error")
+  http_mock_clear()
+}
+
+pipeline test_dispatch_returns_poll_failed_when_snapshot_fails(task) {
+  egress_policy({allow: ["github-api.test", "api.github.test"], default: "deny"})
+  http_mock_clear()
+  http_mock(
+    "GET",
+    BASE
+      + "/repos/octo-org/octo-repo/actions/workflows/private.yml/runs?branch=main&event=workflow_dispatch&per_page=10",
+    {
+      responses: [
+        {
+          status: 403,
+          body: json_stringify({message: "Resource not accessible by integration"}),
+          headers: {"x-ratelimit-remaining": "5"},
+        },
+      ],
+    },
+  )
+  const result = github_dispatch_workflow_and_wait("octo-org", "octo-repo", "private.yml", "main", nil, auth())
+  assert_eq(result.ok, false, "snapshot error fails closed")
+  assert_eq(result.status, "poll_failed", "snapshot error uses existing poll status")
+  assert_eq(result.error.code, "missing_scopes", "connector error is preserved")
+  assert_eq(result.attempts[0].kind, "snapshot_failed", "snapshot stage is structured")
+  assert_eq(len(http_mock_calls()), 1, "failed snapshot prevents dispatch")
   http_mock_clear()
 }
 
@@ -202,9 +342,18 @@ pipeline test_wait_for_workflow_run_times_out_with_known_run(task) {
     "GET",
     BASE + "/repos/octo-org/octo-repo/actions/runs/777",
     {
-      status: 200,
-      body: json_stringify(run_payload(777, "in_progress", nil)),
-      headers: {"x-ratelimit-remaining": "5"},
+      responses: [
+        {
+          status: 200,
+          body: json_stringify(run_payload(777, "in_progress", nil)),
+          headers: {"x-ratelimit-remaining": "5"},
+        },
+        {
+          status: 200,
+          body: json_stringify(run_payload(777, "in_progress", nil)),
+          headers: {"x-ratelimit-remaining": "4"},
+        },
+      ],
     },
   )
   const result = github_wait_for_workflow_run("octo-org", "octo-repo", 777, auth() + {max_attempts: 2})


### PR DESCRIPTION
Closes #162.

## Summary
- snapshot exact matching workflow-run IDs before dispatch
- preserve the returned-run-ID fast path and pin every later poll to that ID
- when GitHub returns no ID, select only one unseen exact run and fail closed with `ambiguous_dispatch` plus candidate IDs
- cover returned-ID, unseen-selection, ambiguity, snapshot failure, dispatch failure, and bounded not-found behavior with deterministic HTTP fixtures

## Verification
- `harn check src`
- `harn lint src`
- `harn fmt --check src tests`
- `harn test tests/ --verbose` (all 25 files)
- `harn connector test .` (8 passed)
- independent `harn test tests/orchestration_helpers.harn --verbose` (18/18)
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-github-connector/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786526857&installation_id=145974243&pr_number=163&repository=burin-labs%2Fharn-github-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-github-connector%2Fpull%2F163&signature=82ce5417e1303e76a222eb6aa10c6cf6267a8d7ae0d5f9e2b9659803a49a1dbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->