### PR TITLE
Expose durable workflow dispatch identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Named helpers:
 | `github_latest_release(owner, repo, options)` | Fetch latest release metadata in a stable envelope. |
 | `github_release_assets(owner, repo, release_id, options)` | List release assets in a stable envelope; defaults to the latest release. |
 | `issues_create_with_template(owner, repo, template, vars, options)` | Render a small title/body template, then create an issue. |
+| `github_dispatch_workflow_and_resolve_run(owner, repo, workflow_id, ref, inputs, options)` | Dispatch a workflow and return its exact run identity before terminal monitoring. |
 | `github_dispatch_workflow_and_wait(owner, repo, workflow_id, ref, inputs, options)` | Dispatch a workflow and wait for its exact run, rejecting ambiguous unseen matches. |
 | `github_wait_for_workflow_run(owner, repo, run_id_or_filter, options)` | Poll an existing workflow run or a filtered run lookup. |
 | `github_ensure_auto_merge(owner, repo, pull_number, options)` | Enable auto-merge and normalize already-enabled responses. |

--- a/changelog.d/164.added.md
+++ b/changelog.d/164.added.md
@@ -1,0 +1,3 @@
+Added a durable workflow dispatch boundary that returns the exact accepted run
+identity before terminal monitoring, while preserving typed dispatch, lookup,
+and ambiguity failures.

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -885,13 +885,14 @@ const DEFAULT_CHECKS_TIMEOUT_MS = 1800000
 const DEFAULT_LOG_TAIL_LINES = 200
 
 /**
- * Dispatch a workflow_dispatch workflow and wait for it to finish. Returns a
+ * Dispatch a workflow_dispatch workflow and resolve its exact run identity.
+ * Returns immediately after pinning a run ID, before terminal monitoring, in a
  * stable `{ok, status, conclusion, run_id, candidate_run_ids, run_url,
  * workflow_id, created_at, started_at, updated_at, attempts, timed_out, error}`
- * envelope. `status` is one of `completed`, `timed_out`, `dispatch_failed`,
- * `ambiguous_dispatch`, `run_not_found`, or `poll_failed`.
+ * envelope. Success has `status: "dispatch_accepted"`; failures preserve
+ * `poll_failed`, `dispatch_failed`, `ambiguous_dispatch`, or `run_not_found`.
  */
-pub fn github_dispatch_workflow_and_wait(
+pub fn github_dispatch_workflow_and_resolve_run(
   owner,
   repo,
   workflow_id,
@@ -934,10 +935,37 @@ pub fn github_dispatch_workflow_and_wait(
     )
   }
   const dispatch_run_id = __extract_dispatch_run_id(dispatch)
+  if dispatch_run_id != nil {
+    return __workflow_wait_envelope(true, "dispatch_accepted", workflow_id, dispatch_run_id, [], false, nil)
+  }
   const dispatch_filter = filter + {excluded_run_ids: snapshot_run_ids, require_unambiguous_dispatch: true}
-  const wait_options = opts + {workflow_id: workflow_id, filter: dispatch_filter}
-  const target = dispatch_run_id ?? dispatch_filter
-  return github_wait_for_workflow_run(owner, repo, target, wait_options)
+  const cfg = __workflow_wait_config(opts + {workflow_id: workflow_id}, dispatch_filter)
+    + {return_on_identity: true}
+  return __workflow_wait_loop(owner, repo, cfg)
+}
+
+/**
+ * Dispatch a workflow_dispatch workflow and wait for it to finish. Returns a
+ * stable `{ok, status, conclusion, run_id, candidate_run_ids, run_url,
+ * workflow_id, created_at, started_at, updated_at, attempts, timed_out, error}`
+ * envelope. `status` is one of `completed`, `timed_out`, `dispatch_failed`,
+ * `ambiguous_dispatch`, `run_not_found`, or `poll_failed`.
+ */
+pub fn github_dispatch_workflow_and_wait(
+  owner,
+  repo,
+  workflow_id,
+  ref = "main",
+  inputs = nil,
+  options = nil,
+) {
+  const opts = options ?? {}
+  const identity = github_dispatch_workflow_and_resolve_run(owner, repo, workflow_id, ref, inputs, opts)
+  if !identity.ok {
+    return identity
+  }
+  const monitored = github_wait_for_workflow_run(owner, repo, identity.run_id, opts + {workflow_id: workflow_id})
+  return monitored + {attempts: identity.attempts + monitored.attempts}
 }
 
 /**
@@ -1076,6 +1104,9 @@ fn __workflow_wait_loop(owner, repo, cfg) {
         )
       }
       run_id = located.run_id
+    }
+    if run_id != nil && (cfg?.return_on_identity ?? false) {
+      return __workflow_wait_envelope(true, "dispatch_accepted", cfg.workflow_id, run_id, attempts, false, nil)
     }
     if run_id != nil {
       const probed = __workflow_wait_probe_step(owner, repo, run_id, cfg.auth, attempt)

--- a/tests/orchestration_helpers.harn
+++ b/tests/orchestration_helpers.harn
@@ -1,5 +1,6 @@
 import {
   github_close_pr,
+  github_dispatch_workflow_and_resolve_run,
   github_dispatch_workflow_and_wait,
   github_ensure_auto_merge,
   github_find_open_pr,
@@ -37,6 +38,50 @@ fn dispatch_returning(run_id) {
 
 fn dispatch_204() {
   return ""
+}
+
+pipeline test_dispatch_identity_returns_returned_run_id_without_monitoring(task) {
+  egress_policy({allow: ["github-api.test", "api.github.test"], default: "deny"})
+  http_mock_clear()
+  const runs_url = BASE
+    + "/repos/octo-org/octo-repo/actions/workflows/identity-returned.yml/runs?branch=main&event=workflow_dispatch&per_page=10"
+  http_mock(
+    "GET",
+    runs_url,
+    {
+      responses: [
+        {
+          status: 200,
+          body: json_stringify({total_count: 0, workflow_runs: []}),
+          headers: {"x-ratelimit-remaining": "31"},
+        },
+      ],
+    },
+  )
+  http_mock(
+    "POST",
+    BASE + "/repos/octo-org/octo-repo/actions/workflows/identity-returned.yml/dispatches",
+    {status: 200, body: dispatch_returning(321), headers: {"x-ratelimit-remaining": "30"}},
+  )
+  const result = github_dispatch_workflow_and_resolve_run(
+    "octo-org",
+    "octo-repo",
+    "identity-returned.yml",
+    "main",
+    nil,
+    auth(),
+  )
+  assert_eq(result.ok, true, "returned run identity succeeds")
+  assert_eq(result.status, "dispatch_accepted", "identity boundary status")
+  assert_eq(result.run_id, 321, "returned run id is pinned")
+  assert_eq(result.candidate_run_ids, [321], "returned identity is structured")
+  assert_eq(result.conclusion, nil, "terminal state is not observed")
+  assert_eq(result.timed_out, false, "identity resolution did not time out")
+  const calls = http_mock_calls()
+  assert_eq(len(calls), 2, "identity boundary stops after snapshot and dispatch")
+  assert_eq(calls[0].url, runs_url, "snapshot precedes dispatch")
+  assert_eq(calls[1].method, "POST", "dispatch follows snapshot")
+  http_mock_clear()
 }
 
 pipeline test_dispatch_with_run_id_completes_success(task) {
@@ -114,7 +159,7 @@ pipeline test_dispatch_with_run_id_completes_success(task) {
   http_mock_clear()
 }
 
-pipeline test_dispatch_selects_only_unseen_exact_run(task) {
+pipeline test_dispatch_identity_selects_only_unseen_exact_run(task) {
   egress_policy({allow: ["github-api.test", "api.github.test"], default: "deny"})
   http_mock_clear()
   const sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
@@ -158,16 +203,7 @@ pipeline test_dispatch_selects_only_unseen_exact_run(task) {
     BASE + "/repos/octo-org/octo-repo/actions/workflows/release.yml/dispatches",
     {status: 204, body: dispatch_204(), headers: {"x-ratelimit-remaining": "20"}},
   )
-  http_mock(
-    "GET",
-    BASE + "/repos/octo-org/octo-repo/actions/runs/901",
-    {
-      status: 200,
-      body: json_stringify(run_payload(901, "completed", "failure", "not-a-timestamp")),
-      headers: {"x-ratelimit-remaining": "18"},
-    },
-  )
-  const result = github_dispatch_workflow_and_wait(
+  const result = github_dispatch_workflow_and_resolve_run(
     "octo-org",
     "octo-repo",
     "release.yml",
@@ -175,20 +211,16 @@ pipeline test_dispatch_selects_only_unseen_exact_run(task) {
     nil,
     auth() + {head_sha: sha},
   )
-  assert_eq(result.status, "completed", "status completed even on failing conclusion")
-  assert_eq(result.ok, true, "ok=true when wait completes")
-  assert_eq(result.conclusion, "failure", "failure conclusion surfaces")
+  assert_eq(result.status, "dispatch_accepted", "identity returns before completion")
+  assert_eq(result.ok, true, "one unseen exact identity succeeds")
+  assert_eq(result.conclusion, nil, "terminal conclusion is not fetched")
   assert_eq(result.run_id, 901, "only unseen exact run selected")
   assert_eq(result.candidate_run_ids, [901], "selected identity is structured")
   const calls = http_mock_calls()
+  assert_eq(len(calls), 3, "identity boundary performs no terminal run GET")
   assert_eq(calls[0].url, runs_url, "pre-dispatch exact ids snapshotted")
   assert_eq(calls[1].method, "POST", "dispatch occurs after snapshot")
   assert_eq(calls[2].url, runs_url, "same exact filter locates unseen runs")
-  assert_eq(
-    calls[3].url,
-    BASE + "/repos/octo-org/octo-repo/actions/runs/901",
-    "selected id is pinned",
-  )
   http_mock_clear()
 }
 
@@ -241,7 +273,7 @@ pipeline test_dispatch_rejects_multiple_unseen_exact_runs(task) {
   http_mock_clear()
 }
 
-pipeline test_dispatch_times_out_when_run_never_appears(task) {
+pipeline test_dispatch_identity_returns_run_not_found_when_run_never_appears(task) {
   egress_policy({allow: ["github-api.test", "api.github.test"], default: "deny"})
   http_mock_clear()
   const runs_url = BASE
@@ -263,7 +295,7 @@ pipeline test_dispatch_times_out_when_run_never_appears(task) {
     BASE + "/repos/octo-org/octo-repo/actions/workflows/never.yml/dispatches",
     {status: 204, body: "", headers: {"x-ratelimit-remaining": "10"}},
   )
-  const result = github_dispatch_workflow_and_wait(
+  const result = github_dispatch_workflow_and_resolve_run(
     "octo-org",
     "octo-repo",
     "never.yml",
@@ -301,7 +333,7 @@ pipeline test_dispatch_returns_dispatch_failed(task) {
       headers: {"x-ratelimit-remaining": "5"},
     },
   )
-  const result = github_dispatch_workflow_and_wait("octo-org", "octo-repo", "broken.yml", "main", nil, auth())
+  const result = github_dispatch_workflow_and_resolve_run("octo-org", "octo-repo", "broken.yml", "main", nil, auth())
   assert_eq(result.ok, false, "ok=false")
   assert_eq(result.status, "dispatch_failed", "status=dispatch_failed")
   assert(result.error != nil, "error captured")
@@ -326,7 +358,14 @@ pipeline test_dispatch_returns_poll_failed_when_snapshot_fails(task) {
       ],
     },
   )
-  const result = github_dispatch_workflow_and_wait("octo-org", "octo-repo", "private.yml", "main", nil, auth())
+  const result = github_dispatch_workflow_and_resolve_run(
+    "octo-org",
+    "octo-repo",
+    "private.yml",
+    "main",
+    nil,
+    auth(),
+  )
   assert_eq(result.ok, false, "snapshot error fails closed")
   assert_eq(result.status, "poll_failed", "snapshot error uses existing poll status")
   assert_eq(result.error.code, "missing_scopes", "connector error is preserved")


### PR DESCRIPTION
Closes #164.

## Summary
- add `github_dispatch_workflow_and_resolve_run`, which returns a pinned exact run ID immediately after dispatch identity resolution
- refactor `github_dispatch_workflow_and_wait` to compose the identity boundary and then monitor only that exact ID
- preserve typed snapshot, dispatch, ambiguity, and not-found failures
- add deterministic fixtures proving returned-ID and no-ID identity return before terminal polling, plus terminal-wait composition

## Verification
- `harn check src`
- `harn lint src`
- `harn fmt --check src tests`
- `harn test tests/ --verbose` (all 25 files)
- `harn connector test .` (8 passed)
- independent `harn test tests/orchestration_helpers.harn --verbose` (19/19)
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-github-connector/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786527496&installation_id=145974243&pr_number=165&repository=burin-labs%2Fharn-github-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-github-connector%2Fpull%2F165&signature=696be94be9667503e6b0a7899401fa7267be9b905709d7bee4e9bbaa075d728f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->