### PR TITLE
Preserve workflow dispatch source identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Named helpers:
 | `pulls_enable_auto_merge(owner, repo, number, options)` | Enable GitHub auto-merge. |
 | `actions_workflow_dispatch(owner, repo, workflow_id, ref, inputs, options)` | Dispatch a workflow. |
 | `actions_workflow_runs(owner, repo, options)` | List workflow runs. |
+| `actions_workflow_run(owner, repo, run_id, options)` | Fetch one workflow run by its exact id. |
 | `actions_workflow_run_jobs(owner, repo, run_id, options)` | List a workflow run's jobs and steps; options support `filter`, `per_page`, and `page`. |
 | `api_call(path, method, body, options)` | Call one REST endpoint. Prefer typed helpers when available. |
 | `repos_get_text(owner, repo, path, ref, options)` | Decode repository file content as UTF-8 text. |

--- a/changelog.d/166.fixed.md
+++ b/changelog.d/166.fixed.md
@@ -1,0 +1,1 @@
+Workflow dispatch identity receipts now preserve the exact run source SHA, branch, event, URL, and timestamps returned by GitHub, and expose a typed helper for fetching one run.

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -722,6 +722,12 @@ pub fn actions_workflow_runs(owner, repo, options = nil) {
   return call("actions.workflow_runs.list", opts + {owner: owner, repo: repo})
 }
 
+/** Fetch one workflow run by its exact id. */
+pub fn actions_workflow_run(owner, repo, run_id, options = nil) {
+  const opts = options ?? {}
+  return call("actions.workflow_run.get", opts + {owner: owner, repo: repo, run_id: run_id})
+}
+
 /** List the jobs and steps for one workflow run. */
 pub fn actions_workflow_run_jobs(owner, repo, run_id, options = nil) {
   const opts = options ?? {}
@@ -888,7 +894,8 @@ const DEFAULT_LOG_TAIL_LINES = 200
  * Dispatch a workflow_dispatch workflow and resolve its exact run identity.
  * Returns immediately after pinning a run ID, before terminal monitoring, in a
  * stable `{ok, status, conclusion, run_id, candidate_run_ids, run_url,
- * workflow_id, created_at, started_at, updated_at, attempts, timed_out, error}`
+ * workflow_id, head_sha, head_branch, event, created_at, started_at,
+ * updated_at, attempts, timed_out, error}`
  * envelope. Success has `status: "dispatch_accepted"`; failures preserve
  * `poll_failed`, `dispatch_failed`, `ambiguous_dispatch`, or `run_not_found`.
  */
@@ -947,7 +954,8 @@ pub fn github_dispatch_workflow_and_resolve_run(
 /**
  * Dispatch a workflow_dispatch workflow and wait for it to finish. Returns a
  * stable `{ok, status, conclusion, run_id, candidate_run_ids, run_url,
- * workflow_id, created_at, started_at, updated_at, attempts, timed_out, error}`
+ * workflow_id, head_sha, head_branch, event, created_at, started_at,
+ * updated_at, attempts, timed_out, error}`
  * envelope. `status` is one of `completed`, `timed_out`, `dispatch_failed`,
  * `ambiguous_dispatch`, `run_not_found`, or `poll_failed`.
  */
@@ -1085,6 +1093,7 @@ fn __workflow_wait_loop(owner, repo, cfg) {
   let attempts = []
   let attempt = 0
   let run_id = cfg.initial_run_id
+  let identity_run = nil
   let last_run = nil
   while attempt < cfg.max_attempts {
     attempt = attempt + 1
@@ -1104,8 +1113,13 @@ fn __workflow_wait_loop(owner, repo, cfg) {
         )
       }
       run_id = located.run_id
+      identity_run = located?.run
     }
     if run_id != nil && (cfg?.return_on_identity ?? false) {
+      if identity_run != nil {
+        return __workflow_envelope_from_run(true, "dispatch_accepted", identity_run, attempts, false, nil)
+          + {workflow_id: cfg.workflow_id}
+      }
       return __workflow_wait_envelope(true, "dispatch_accepted", cfg.workflow_id, run_id, attempts, false, nil)
     }
     if run_id != nil {
@@ -1149,6 +1163,7 @@ fn __workflow_wait_locate_step(owner, repo, filter, auth, attempt) {
   return {
     attempts: [{attempt: attempt, kind: "located", run_id: located.id, created_at: located?.created_at}],
     run_id: located.id,
+    run: located,
   }
 }
 
@@ -1185,6 +1200,7 @@ fn __workflow_wait_locate_dispatch_step(owner, repo, filter, auth, attempt) {
   return {
     attempts: [{attempt: attempt, kind: "located", run_id: run_ids[0], created_at: unseen[0]?.created_at}],
     run_id: run_ids[0],
+    run: unseen[0],
     candidate_run_ids: run_ids,
   }
 }
@@ -1571,6 +1587,9 @@ fn __workflow_wait_envelope(
     },
     run_url: nil,
     workflow_id: workflow_id,
+    head_sha: nil,
+    head_branch: nil,
+    event: nil,
     created_at: nil,
     started_at: nil,
     updated_at: nil,
@@ -1593,6 +1612,9 @@ fn __workflow_envelope_from_run(ok, status, run, attempts, timed_out, error) {
     },
     run_url: run?.html_url ?? run?.url,
     workflow_id: run?.workflow_id,
+    head_sha: run?.head_sha,
+    head_branch: run?.head_branch,
+    event: run?.event,
     created_at: run?.created_at,
     started_at: run?.run_started_at ?? run?.started_at,
     updated_at: run?.updated_at,

--- a/tests/orchestration_helpers.harn
+++ b/tests/orchestration_helpers.harn
@@ -75,6 +75,9 @@ pipeline test_dispatch_identity_returns_returned_run_id_without_monitoring(task)
   assert_eq(result.status, "dispatch_accepted", "identity boundary status")
   assert_eq(result.run_id, 321, "returned run id is pinned")
   assert_eq(result.candidate_run_ids, [321], "returned identity is structured")
+  assert_eq(result.head_sha, nil, "direct-id dispatch has no observed source sha")
+  assert_eq(result.head_branch, nil, "direct-id dispatch has no observed source branch")
+  assert_eq(result.event, nil, "direct-id dispatch has no observed event")
   assert_eq(result.conclusion, nil, "terminal state is not observed")
   assert_eq(result.timed_out, false, "identity resolution did not time out")
   const calls = http_mock_calls()
@@ -138,6 +141,13 @@ pipeline test_dispatch_with_run_id_completes_success(task) {
   assert_eq(result.conclusion, "success", "conclusion success")
   assert_eq(result.run_id, 123, "run id from dispatch")
   assert_eq(result.workflow_id, 4242, "workflow id from run")
+  assert_eq(
+    result.head_sha,
+    "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    "terminal run preserves source sha",
+  )
+  assert_eq(result.head_branch, "main", "terminal run preserves source branch")
+  assert_eq(result.event, "workflow_dispatch", "terminal run preserves event")
   assert(result.run_url.contains("/actions/runs/123"), "run url")
   assert_eq(result.timed_out, false, "not timed out")
   assert(len(result.attempts) >= 2, "polled at least twice")
@@ -216,6 +226,16 @@ pipeline test_dispatch_identity_selects_only_unseen_exact_run(task) {
   assert_eq(result.conclusion, nil, "terminal conclusion is not fetched")
   assert_eq(result.run_id, 901, "only unseen exact run selected")
   assert_eq(result.candidate_run_ids, [901], "selected identity is structured")
+  assert_eq(result.head_sha, sha, "identity preserves the actual observed source sha")
+  assert_eq(result.head_branch, "main", "identity preserves the observed source branch")
+  assert_eq(result.event, "workflow_dispatch", "identity preserves the observed event")
+  assert_eq(result.workflow_id, "release.yml", "identity preserves the requested workflow id")
+  assert(result.run_url.contains("/actions/runs/901"), "identity preserves the observed run url")
+  assert_eq(
+    result.created_at,
+    "not-a-timestamp",
+    "identity preserves source timestamps without parsing",
+  )
   const calls = http_mock_calls()
   assert_eq(len(calls), 3, "identity boundary performs no terminal run GET")
   assert_eq(calls[0].url, runs_url, "pre-dispatch exact ids snapshotted")
@@ -399,6 +419,13 @@ pipeline test_wait_for_workflow_run_times_out_with_known_run(task) {
   assert_eq(result.status, "timed_out", "status=timed_out")
   assert_eq(result.timed_out, true, "timed_out flag set")
   assert_eq(result.run_id, 777, "still surfaces last known run")
+  assert_eq(
+    result.head_sha,
+    "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    "timeout preserves source sha",
+  )
+  assert_eq(result.head_branch, "main", "timeout preserves source branch")
+  assert_eq(result.event, "workflow_dispatch", "timeout preserves source event")
   assert_eq(result.ok, false, "ok=false on timeout")
   http_mock_clear()
 }

--- a/tests/repo_automation_methods.harn
+++ b/tests/repo_automation_methods.harn
@@ -1,5 +1,6 @@
 import {
   actions_workflow_dispatch,
+  actions_workflow_run,
   actions_workflow_runs,
   api_call,
   call,
@@ -98,7 +99,7 @@ pipeline test_repo_automation_methods(task) {
       headers: {"x-ratelimit-remaining": "7"},
     },
   )
-  const run = call("actions.workflow_run.get", auth + {owner: "octo-org", repo: "octo-repo", run_id: 123})
+  const run = actions_workflow_run("octo-org", "octo-repo", 123, auth)
   assert_eq(run.conclusion, "success", "workflow run get response")
   http_mock(
     "GET",


### PR DESCRIPTION
Closes #166

## Summary
- preserve the exact located workflow run through dispatch identity resolution
- add `head_sha`, `head_branch`, and `event` to every stable workflow-run envelope
- expose `actions_workflow_run` so callers no longer use raw operation names
- keep direct-ID dispatch immediate with explicitly nil unobserved metadata

## Verification
- `harn check src`
- `harn lint src`
- `harn fmt --check src tests`
- every `tests/*.harn` pipeline
- `harn connector check .`
- temporary consumer `harn add <worktree>` + `harn check smoke.harn`
- signed commit verification

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-github-connector/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786539082&installation_id=145974243&pr_number=167&repository=burin-labs%2Fharn-github-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-github-connector%2Fpull%2F167&signature=236c4824c7222b502651aad8e89c8ee5f730673a3bb807c7902e88a44bb8ffa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->