### PR TITLE
Hydrate exact workflow dispatch identities

### DIFF
--- a/changelog.d/168.fixed.md
+++ b/changelog.d/168.fixed.md
@@ -1,0 +1,1 @@
+Workflow dispatch identity resolution now hydrates exact run metadata before reporting success, including when GitHub returns a run ID before the run is observable.

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -943,7 +943,9 @@ pub fn github_dispatch_workflow_and_resolve_run(
   }
   const dispatch_run_id = __extract_dispatch_run_id(dispatch)
   if dispatch_run_id != nil {
-    return __workflow_wait_envelope(true, "dispatch_accepted", workflow_id, dispatch_run_id, [], false, nil)
+    const direct_cfg = __workflow_wait_config(opts + {workflow_id: workflow_id}, dispatch_run_id)
+      + {return_on_identity: true}
+    return __workflow_wait_loop(owner, repo, direct_cfg)
   }
   const dispatch_filter = filter + {excluded_run_ids: snapshot_run_ids, require_unambiguous_dispatch: true}
   const cfg = __workflow_wait_config(opts + {workflow_id: workflow_id}, dispatch_filter)
@@ -1115,18 +1117,19 @@ fn __workflow_wait_loop(owner, repo, cfg) {
       run_id = located.run_id
       identity_run = located?.run
     }
-    if run_id != nil && (cfg?.return_on_identity ?? false) {
-      if identity_run != nil {
+    if run_id != nil {
+      if (cfg?.return_on_identity ?? false) && identity_run != nil {
         return __workflow_envelope_from_run(true, "dispatch_accepted", identity_run, attempts, false, nil)
           + {workflow_id: cfg.workflow_id}
       }
-      return __workflow_wait_envelope(true, "dispatch_accepted", cfg.workflow_id, run_id, attempts, false, nil)
-    }
-    if run_id != nil {
       const probed = __workflow_wait_probe_step(owner, repo, run_id, cfg.auth, attempt)
       attempts = attempts + probed.attempts
       if probed.run != nil {
         last_run = probed.run
+        if cfg?.return_on_identity ?? false {
+          return __workflow_envelope_from_run(true, "dispatch_accepted", probed.run, attempts, false, nil)
+            + {workflow_id: cfg.workflow_id}
+        }
       }
       if probed.completed {
         return __workflow_envelope_from_run(true, "completed", probed.run, attempts, false, nil)

--- a/tests/orchestration_helpers.harn
+++ b/tests/orchestration_helpers.harn
@@ -40,7 +40,7 @@ fn dispatch_204() {
   return ""
 }
 
-pipeline test_dispatch_identity_returns_returned_run_id_without_monitoring(task) {
+pipeline test_dispatch_identity_hydrates_returned_run_id_after_eventual_consistency(task) {
   egress_policy({allow: ["github-api.test", "api.github.test"], default: "deny"})
   http_mock_clear()
   const runs_url = BASE
@@ -63,6 +63,24 @@ pipeline test_dispatch_identity_returns_returned_run_id_without_monitoring(task)
     BASE + "/repos/octo-org/octo-repo/actions/workflows/identity-returned.yml/dispatches",
     {status: 200, body: dispatch_returning(321), headers: {"x-ratelimit-remaining": "30"}},
   )
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/actions/runs/321",
+    {
+      responses: [
+        {
+          status: 404,
+          body: json_stringify({message: "Not Found"}),
+          headers: {"x-ratelimit-remaining": "29"},
+        },
+        {
+          status: 200,
+          body: json_stringify(run_payload(321, "queued", nil)),
+          headers: {"x-ratelimit-remaining": "28"},
+        },
+      ],
+    },
+  )
   const result = github_dispatch_workflow_and_resolve_run(
     "octo-org",
     "octo-repo",
@@ -75,15 +93,21 @@ pipeline test_dispatch_identity_returns_returned_run_id_without_monitoring(task)
   assert_eq(result.status, "dispatch_accepted", "identity boundary status")
   assert_eq(result.run_id, 321, "returned run id is pinned")
   assert_eq(result.candidate_run_ids, [321], "returned identity is structured")
-  assert_eq(result.head_sha, nil, "direct-id dispatch has no observed source sha")
-  assert_eq(result.head_branch, nil, "direct-id dispatch has no observed source branch")
-  assert_eq(result.event, nil, "direct-id dispatch has no observed event")
+  assert_eq(
+    result.head_sha,
+    "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    "direct-id dispatch hydrates the observed source sha",
+  )
+  assert_eq(result.head_branch, "main", "direct-id dispatch hydrates the observed source branch")
+  assert_eq(result.event, "workflow_dispatch", "direct-id dispatch hydrates the observed event")
+  assert(result.run_url.contains("/actions/runs/321"), "direct-id dispatch hydrates the run URL")
   assert_eq(result.conclusion, nil, "terminal state is not observed")
   assert_eq(result.timed_out, false, "identity resolution did not time out")
   const calls = http_mock_calls()
-  assert_eq(len(calls), 2, "identity boundary stops after snapshot and dispatch")
+  assert_eq(len(calls), 4, "identity boundary retries the exact run until metadata is observable")
   assert_eq(calls[0].url, runs_url, "snapshot precedes dispatch")
   assert_eq(calls[1].method, "POST", "dispatch follows snapshot")
+  assert_eq(calls[2].url, calls[3].url, "eventual-consistency retry keeps the exact run identity")
   http_mock_clear()
 }
 


### PR DESCRIPTION
Closes #168.

## What changed

- treats a direct workflow run ID as a locator, not a complete durable identity
- polls the exact run endpoint until URL, source SHA, branch, and event are observable
- preserves the existing bounded attempt/timeout contract and fails closed when metadata never appears
- adds a deterministic zero-delay eventual-consistency test (404 then exact run)

## Verification

- `harn check src`
- `harn lint src`
- `harn fmt --check src tests`
- every `tests/*.harn` smoke file
- `harn connector check .`

Dogfood root cause: Harn v0.10.15 warm dispatch created run 29256142800, but the pre-fix helper returned accepted partial identity that HBF correctly rejected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-github-connector/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786543752&installation_id=145974243&pr_number=169&repository=burin-labs%2Fharn-github-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-github-connector%2Fpull%2F169&signature=ededb72b714301dc8b0301cd708130e589c825e6f7e37ddfefaca9032bf23839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->