### PR TITLE
Add typed GitHub orchestration contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,42 @@ Call methods through `call(method, args)` unless a named helper fits better.
 
 | Area | Methods |
 |---|---|
-| Pull requests | `github.pr.list`, `github.pr.view`, `github.pr.edit`, `github.pr.checks`, `github.pr.merge`, `github.pr.enable_auto_merge`, `github.pr.comment`, `pulls.list`, `pulls.list_with_checks`, `pulls.get`, `pulls.update`, `pulls.create`, `pulls.merge`, `pulls.merge_safe`, `pulls.create_review_comment`, `pulls.get_diff`, `pulls.list_files`, `pulls.list_reviews`, `pull_requests.resolve_mergeable`, `repos.commit_pulls` |
-| Actions and checks | `github.actions.workflow_dispatch`, `github.actions.runs`, `github.actions.run`, `github.actions.logs`, `actions.workflow_dispatch`, `actions.workflow_runs.list`, `actions.workflow_run.get`, `actions.workflow_run.jobs`, `check_runs.create`, `check_runs.update` |
+| Pull requests | `github.pr.list`, `github.pr.create`, `github.pr.view`, `github.pr.edit`, `github.pr.files`, `github.pr.checks`, `github.pr.merge`, `github.pr.enable_auto_merge`, `github.pr.comment`, `pulls.list`, `pulls.list_with_checks`, `pulls.get`, `pulls.update`, `pulls.create`, `pulls.merge`, `pulls.merge_safe`, `pulls.create_review_comment`, `pulls.get_diff`, `pulls.list_files`, `pulls.list_reviews`, `pull_requests.resolve_mergeable`, `repos.commit_pulls` |
+| Actions and checks | `github.actions.workflow_dispatch`, `github.actions.runs`, `github.actions.run`, `github.actions.run_jobs`, `github.actions.logs`, `actions.workflow_dispatch`, `actions.workflow_runs.list`, `actions.workflow_run.get`, `actions.workflow_run.jobs`, `check_runs.create`, `check_runs.update` |
 | Self-hosted runners | `actions.runners.registration_token`, `actions.runners.remove_token`, `actions.runners.generate_jitconfig`, `actions.runners.list`, `actions.runners.get`, `actions.runners.delete`, `actions.runners.downloads`, `actions.runners.labels.list`, `actions.runners.labels.add`, `actions.runners.labels.replace`, `actions.runners.labels.remove`, `actions.runner_groups.list`, `actions.runner_groups.create`, `actions.runner_groups.get`, `actions.runner_groups.update`, `actions.runner_groups.delete` |
 | User OAuth | `oauth.user.device_code`, `oauth.user.device_poll`, `oauth.user.exchange_code`, `oauth.user.refresh` |
 | Issues | `github.issue.create`, `github.issue.comment`, `issues.create_comment`, `issues.create`, `issues.create_with_template`, `issues.update`, `issues.add_labels` |
-| Repository and release data | `github.release.latest`, `github.release.assets`, `github.branch.protection`, `github.branch.create_signed_commit`, `repos.get_content`, `repos.get_text`, `repos.create_or_update_file`, `repos.put_content`, `repos.delete_file`, `repos.get_latest_release`, `repos.list_release_assets`, `repos.get_branch_protection`, `git.create_commit`, `git.delete_ref` |
-| Merge queue | `github.merge_queue.entries`, `github.merge_queue.enqueue` |
+| Repository and release data | `github.file.view`, `github.release.view`, `github.release.latest`, `github.release.assets`, `github.commit.signature`, `github.branch.protection`, `github.branch.create_signed_commit`, `repos.get_content`, `repos.get_text`, `repos.create_or_update_file`, `repos.put_content`, `repos.delete_file`, `repos.get_latest_release`, `repos.list_release_assets`, `repos.get_branch_protection`, `git.create_commit`, `git.delete_ref` |
+| Merge queue | `github.merge_queue.entries`, `github.merge_queue.membership`, `github.merge_queue.enqueue` |
 | Raw access | `api_call`, `graphql` |
+
+The namespaced methods above are the canonical automation boundary. Covered
+operations return one closed normalized record or `Err({code, category,
+message, http_status?})`; callers should not issue their own GraphQL or parse
+raw REST responses for the same operation.
+
+- `github.pr.enable_auto_merge` and `github.merge_queue.enqueue` require
+  `expected_head_oid`. A mismatched lease returns `stale_head` without mutating.
+- `github.merge_queue.membership` reports `queued: true` only when GitHub
+  returns a `mergeQueueEntry`. An `autoMergeRequest` is reported separately as
+  `auto_merge_armed`.
+- `github.pr.view` keeps the base PR read when branch-protection administration
+  permission is unavailable. Its `branch_protection.available` is `false` and
+  retains the structured permission error.
+- `github.actions.workflow_dispatch` resolves one exact accepted run identity;
+  `github.actions.run` and `github.actions.run_jobs` return closed run, job, and
+  step evidence.
+- `github.file.view` requires an exact `ref`, and `github.release.view` requires
+  an exact `tag`. They return `state: "found" | "absent"`; a `404` is absence
+  only after the same credential proves repository access. Masked private
+  resources and transport failures remain `Err`.
+- `github.commit.signature` returns GitHub's normalized `verified`, `reason`,
+  material-presence, and `verified_at` evidence. Unsigned and invalid
+  signatures are successful reads with `verified: false`, not transport errors.
+
+`api_call`, `graphql`, and the unnamespaced methods remain low-level escape
+hatches for operations without a canonical method. They are not compatibility
+paths for the methods above.
 
 Named helpers:
 
@@ -148,7 +176,7 @@ Named helpers:
 | `pulls_list_with_checks(owner, repo, state, limit, options)` | List PRs with merge state and CI rollup. |
 | `pulls_update(owner, repo, number, edits, options)` | Update a closed set of editable PR fields. |
 | `pulls_merge_safe(owner, repo, number, options)` | Merge after checking branch protection. |
-| `pulls_enable_auto_merge(owner, repo, number, options)` | Enable GitHub auto-merge. |
+| `pulls_enable_auto_merge(owner, repo, number, options)` | Enable GitHub auto-merge; `options.expected_head_oid` is required. |
 | `actions_workflow_dispatch(owner, repo, workflow_id, ref, inputs, options)` | Dispatch a workflow. |
 | `actions_workflow_runs(owner, repo, options)` | List workflow runs. |
 | `actions_workflow_run(owner, repo, run_id, options)` | Fetch one workflow run by its exact id. |
@@ -163,13 +191,14 @@ Named helpers:
 | `github_dispatch_workflow_and_resolve_run(owner, repo, workflow_id, ref, inputs, options)` | Dispatch a workflow and return its exact run identity before terminal monitoring. |
 | `github_dispatch_workflow_and_wait(owner, repo, workflow_id, ref, inputs, options)` | Dispatch a workflow and wait for its exact run, rejecting ambiguous unseen matches. |
 | `github_wait_for_workflow_run(owner, repo, run_id_or_filter, options)` | Poll an existing workflow run or a filtered run lookup. |
-| `github_ensure_auto_merge(owner, repo, pull_number, options)` | Enable auto-merge and normalize already-enabled responses. |
+| `github_ensure_auto_merge(owner, repo, pull_number, options)` | Enable auto-merge under required `options.expected_head_oid`; returns the canonical `Result`. |
 | `github_wait_for_pr_checks(owner, repo, pull_number_or_ref, options)` | Wait for visible PR or commit checks; optionally attach failing Actions log tails. |
 | `github_find_open_pr(owner, repo, options)` | Find the first open PR matching `head_ref`, `base_ref`, `title`, or `labels`. |
 | `github_close_pr(owner, repo, pull_number, comment, options)` | Close a PR and optionally post a final comment. |
 | `github_resolve_mergeable(owner, repo, pull_number, options)` | Resolve a PR's async `mergeable`/`mergeable_state` with bounded polling; returns `{mergeable, mergeable_state, is_conflict, ...}`. |
 | `github_resolve_pr_for_sha(owner, repo, sha, options)` | Resolve the PR for a commit SHA, preferring payload `pull_requests[]` and falling back to `repos.commit_pulls`. |
 | `github_create_signed_commit(request, options)` | Atomically append file additions/deletions at an expected head OID through GitHub's verified App-signing path. |
+| `github_release(owner, repo, tag, options)` | Look up one exact release tag with proven-absence semantics. |
 | `github_extract_mentions(body)` | Pure string parse of `@handle command args...` mentions in a body. |
 | `actions_runner_registration_token(scope, options)` | Create a self-hosted runner registration token (`scope` is `{org}` or `{owner, repo}`). |
 | `actions_runner_generate_jitconfig(scope, name, runner_group_id, labels, options)` | Generate a stateless single-use JIT runner config. |

--- a/changelog.d/171.added.md
+++ b/changelog.d/171.added.md
@@ -1,0 +1,6 @@
+Added canonical closed typed GitHub orchestration methods for pull request
+create/list/files/comments, expected-head auto-merge, merge queue evidence,
+exact workflow runs/jobs, commit signatures, and exact file/release lookups.
+PR reads now preserve unavailable branch-protection enrichment, queue membership
+no longer treats armed auto-merge as queued, and masked 404s fail closed unless
+repository access independently proves absence.

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -15,8 +15,10 @@ const GITHUB_USER_AGENT = "harn-github-connector"
 
 const GITHUB_OUTBOUND_METHODS = [
   "github.pr.list",
+  "github.pr.create",
   "github.pr.view",
   "github.pr.edit",
+  "github.pr.files",
   "github.pr.checks",
   "github.pr.merge",
   "github.pr.enable_auto_merge",
@@ -24,16 +26,20 @@ const GITHUB_OUTBOUND_METHODS = [
   "github.actions.workflow_dispatch",
   "github.actions.runs",
   "github.actions.run",
+  "github.actions.run_jobs",
   "github.actions.logs",
   "github.release.view",
   "github.release.latest",
   "github.release.assets",
   "github.merge_queue.entries",
+  "github.merge_queue.membership",
   "github.merge_queue.enqueue",
   "github.issue.create",
   "github.issue.comment",
   "github.branch.protection",
   "github.branch.create_signed_commit",
+  "github.commit.signature",
+  "github.file.view",
   "github.app.installation_token",
   "api_call",
   "issues.create_comment",
@@ -138,6 +144,65 @@ type GithubSignedCommitReceipt = {
   signature_valid: bool,
   signed_by_github: bool,
   signature_state: string,
+}
+
+type GithubPullRequestRef = {ref: string, sha: string, repo: string, owner: string}
+
+type GithubPullRequestUser = {id: int?, login: string, type: string}
+
+type GithubPullRequestSummary = {
+  repo: string,
+  number: int,
+  title: string,
+  url: string,
+  state: string,
+  github_state: string,
+  draft: bool,
+  merged: bool,
+  mergeable: bool?,
+  mergeable_state: string,
+  base: GithubPullRequestRef,
+  head: GithubPullRequestRef,
+  labels: list<string>,
+  auto_merge_armed: bool,
+  in_merge_queue: bool?,
+}
+
+type GithubPullRequestFile = {
+  sha: string,
+  filename: string,
+  status: string,
+  additions: int,
+  deletions: int,
+  changes: int,
+  previous_filename: string?,
+  blob_url: string?,
+  raw_url: string?,
+  contents_url: string?,
+}
+
+type GithubMergeQueueEntry = {
+  id: string,
+  pull_number: int,
+  url: string,
+  state: string,
+  position: int,
+  enqueued_at: string?,
+  head_sha: string,
+  base_branch: string,
+  jump: bool,
+  solo: bool,
+  estimated_time_to_merge_seconds: int?,
+}
+
+type GithubCommitSignature = {
+  repo: string,
+  sha: string,
+  verified: bool,
+  reason: string,
+  signature_present: bool,
+  payload_present: bool,
+  verified_at: string?,
 }
 
 type GithubConnectorState = {initialized: bool, active: bool, bindings: dict, ctx: dict}
@@ -329,11 +394,17 @@ pub fn call(method, args = {}) {
   if method == "github.pr.list" {
     return __github_pr_list(args, cfg)
   }
+  if method == "github.pr.create" {
+    return __github_pr_create(args, cfg)
+  }
   if method == "github.pr.view" {
     return __github_pr_view(args, cfg)
   }
   if method == "github.pr.edit" {
     return __github_pr_edit(args, cfg)
+  }
+  if method == "github.pr.files" {
+    return __github_pr_files(args, cfg)
   }
   if method == "github.pr.checks" {
     return __github_pr_checks(args, cfg)
@@ -345,7 +416,7 @@ pub fn call(method, args = {}) {
     return __github_pr_enable_auto_merge(args, cfg)
   }
   if method == "github.pr.comment" {
-    return __github_issue_comment(args + {issue_number: args?.pr_number ?? args?.number}, cfg)
+    return __github_pr_comment(args, cfg)
   }
   if method == "github.actions.workflow_dispatch" {
     return __github_actions_workflow_dispatch(args, cfg)
@@ -355,6 +426,9 @@ pub fn call(method, args = {}) {
   }
   if method == "github.actions.run" {
     return __github_actions_run(args, cfg)
+  }
+  if method == "github.actions.run_jobs" {
+    return __github_actions_run_jobs(args, cfg)
   }
   if method == "github.actions.logs" {
     return __github_actions_logs(args, cfg)
@@ -371,6 +445,9 @@ pub fn call(method, args = {}) {
   if method == "github.merge_queue.entries" {
     return __github_merge_queue_entries(args, cfg)
   }
+  if method == "github.merge_queue.membership" {
+    return __github_merge_queue_membership(args, cfg)
+  }
   if method == "github.merge_queue.enqueue" {
     return __github_merge_queue_enqueue(args, cfg)
   }
@@ -385,6 +462,12 @@ pub fn call(method, args = {}) {
   }
   if method == "github.branch.create_signed_commit" {
     return __github_create_signed_commit(args, cfg)
+  }
+  if method == "github.commit.signature" {
+    return __github_commit_signature(args, cfg)
+  }
+  if method == "github.file.view" {
+    return __github_file_view(args, cfg)
   }
   if method == "api_call" {
     return __api_call(args, cfg)
@@ -853,14 +936,10 @@ pub fn github_latest_release(owner, repo, options = nil) {
   return call("github.release.latest", opts + {owner: owner, repo: repo})
 }
 
-/** Fetch release metadata by tag, or the latest release when the tag is nil. */
-pub fn github_release(owner, repo, tag = nil, options = nil) {
+/** Look up release metadata by one exact tag. */
+pub fn github_release(owner, repo, tag, options = nil) {
   const opts = options ?? {}
-  let args = opts + {owner: owner, repo: repo}
-  if tag != nil {
-    args["tag"] = tag
-  }
-  return call("github.release.view", args)
+  return call("github.release.view", opts + {owner: owner, repo: repo, tag: tag})
 }
 
 /**
@@ -990,20 +1069,10 @@ pub fn github_wait_for_workflow_run(owner, repo, run_id_or_filter, options = nil
   return __workflow_wait_loop(owner, repo, cfg)
 }
 
-/**
- * Enable GitHub auto-merge for a PR through the GraphQL mutation, normalizing
- * `merge`/`squash`/`rebase` and treating already-enabled as success. Returns
- * a stable `{ok, state, already_enabled, requested_method, merge_method,
- * pull_number, url, strategy, error}` envelope.
- */
+/** Enable auto-merge under an explicit `expected_head_oid` lease. */
 pub fn github_ensure_auto_merge(owner, repo, pull_number, options = nil) {
   const opts = options ?? {}
-  const requested_method = uppercase(to_string(opts?.method ?? opts?.merge_method ?? "merge"))
-  const result = pulls_enable_auto_merge(owner, repo, pull_number, opts)
-  if is_err(result) {
-    return __auto_merge_failed_envelope(requested_method, pull_number, unwrap_err(result))
-  }
-  return __auto_merge_success_envelope(result, requested_method, pull_number)
+  return pulls_enable_auto_merge(owner, repo, pull_number, opts)
 }
 
 /**
@@ -1395,38 +1464,6 @@ fn __close_pr_envelope(ok, pull_number, comment_posted, pull_request, error) {
   }
 }
 
-fn __auto_merge_failed_envelope(requested_method, pull_number, error) {
-  return {
-    ok: false,
-    state: "failed",
-    already_enabled: false,
-    requested_method: requested_method,
-    merge_method: nil,
-    pull_number: pull_number,
-    url: nil,
-    strategy: "graphql_auto_merge",
-    error: error,
-  }
-}
-
-fn __auto_merge_success_envelope(result, requested_method, pull_number) {
-  const state = result?.state ?? "enabled"
-  const merge_method = result?.requested_method ?? result?.auto_merge?.merge_method
-    ?? result?.pull_request?.autoMergeRequest?.mergeMethod
-    ?? requested_method
-  return {
-    ok: true,
-    state: state,
-    already_enabled: state == "already_enabled",
-    requested_method: requested_method,
-    merge_method: to_string(merge_method),
-    pull_number: pull_number,
-    url: result?.pull_request?.html_url ?? result?.pull_request?.url,
-    strategy: "graphql_auto_merge",
-    error: nil,
-  }
-}
-
 fn __auth_options(options) {
   let auth = {}
   for key in __config_keys() {
@@ -1798,14 +1835,63 @@ fn __github_pr_list(args, cfg) {
   if is_err(pulls) {
     return pulls
   }
+  if type_of(pulls) != "list" {
+    return __err("invalid_response", "github.pr.list expected GitHub to return a pull-request list")
+  }
   let typed = []
   for pull in pulls {
+    const valid = __validate_pull_response(pull, "github.pr.list")
+    if is_err(valid) {
+      return valid
+    }
     if requested_state == "merged" && pull?.merged_at == nil && !(pull?.merged ?? false) {
       continue
     }
     typed = typed + [__typed_pr_summary(pull)]
   }
   return typed
+}
+
+fn __github_pr_create(args, cfg) {
+  const repo = __repo_parts(args)
+  if is_err(repo) {
+    return repo
+  }
+  const r = unwrap(repo)
+  if trim(to_string(args?.title ?? "")) == "" || trim(to_string(args?.head ?? "")) == ""
+    || trim(to_string(args?.base ?? "")) == "" {
+    return __err("schema_drift", "github.pr.create requires non-empty title, head, and base")
+  }
+  let request = {
+    owner: r.owner,
+    repo: r.name,
+    title: to_string(args.title),
+    head: to_string(args.head),
+    base: to_string(args.base),
+  }
+  const optional_fields = [
+    "body",
+    "draft",
+    "maintainer_can_modify",
+    "github_author_choice",
+    "author_choice",
+    "author_mode",
+    "trailers",
+  ]
+  for field in optional_fields {
+    if args.get(field) != nil {
+      request[field] = args.get(field)
+    }
+  }
+  const created = __pulls_create(request, cfg)
+  if is_err(created) {
+    return created
+  }
+  const valid = __validate_pull_response(created, "github.pr.create")
+  if is_err(valid) {
+    return valid
+  }
+  return __typed_pr_details(created) + {created: true}
 }
 
 fn __github_pr_view(args, cfg) {
@@ -1830,12 +1916,29 @@ fn __github_pr_view(args, cfg) {
   if is_err(pull) {
     return pull
   }
+  const valid = __validate_pull_response(pull, "github.pr.view")
+  if is_err(valid) {
+    return valid
+  }
   const base_branch = pull?.base?.ref ?? args?.branch ?? args?.base_branch
   const protection = __github_branch_protection_raw(r, base_branch, cfg)
+  let protection_evidence = nil
   if is_err(protection) {
-    return protection
+    const protection_error = unwrap_err(protection)
+    if protection_error?.category != "permission" {
+      return protection
+    }
+    protection_evidence = __branch_protection_unavailable(base_branch, protection_error)
+  } else {
+    protection_evidence = __branch_protection_summary(unwrap(protection), base_branch)
   }
-  return __typed_pr_view(pull, unwrap(protection))
+  const membership = __github_merge_queue_membership(args + {owner: r.owner, repo: r.name, pull_number: number}, cfg)
+  const queue_evidence = if is_err(membership) {
+    __queue_membership_unavailable(r.full_name, number, unwrap_err(membership), pull?.auto_merge != nil)
+  } else {
+    membership
+  }
+  return __typed_pr_view(pull, protection_evidence, queue_evidence)
 }
 
 fn __github_pr_edit(args, cfg) {
@@ -1853,6 +1956,70 @@ fn __github_pr_edit(args, cfg) {
     return updated
   }
   return __typed_pr_edit(updated)
+}
+
+fn __github_pr_files(args, cfg) {
+  const repo = __repo_parts(args)
+  if is_err(repo) {
+    return repo
+  }
+  const r = unwrap(repo)
+  const number = args?.pr_number ?? args?.number ?? args?.pull_number
+  if number == nil {
+    return __err("schema_drift", "github.pr.files requires number, pr_number, or pull_number")
+  }
+  const files = __github_json(
+    "GET",
+    __github_api_url(
+      cfg.api_base_url,
+      "/repos/" + r.owner + "/" + r.name + "/pulls/" + to_string(number) + "/files"
+        + __pagination_query(args),
+    ),
+    nil,
+    cfg,
+  )
+  if is_err(files) {
+    return files
+  }
+  if type_of(files) != "list" {
+    return __err("invalid_response", "github.pr.files expected GitHub to return a file list")
+  }
+  let normalized = []
+  for file in files {
+    const typed = __typed_pr_file(file)
+    if is_err(typed) {
+      return typed
+    }
+    normalized = normalized + [unwrap(typed)]
+  }
+  return {
+    repo: r.full_name,
+    pull_number: to_int(number),
+    files: normalized,
+    page: if args?.page == nil {
+      1
+    } else {
+      to_int(args.page)
+    },
+    per_page: if args?.per_page == nil {
+      30
+    } else {
+      to_int(args.per_page)
+    },
+  }
+}
+
+fn __github_pr_comment(args, cfg) {
+  const commented = __github_issue_comment(
+    args + {issue_number: args?.pr_number ?? args?.number ?? args?.pull_number},
+    cfg,
+  )
+  if is_err(commented) {
+    return commented
+  }
+  let result = commented + {pull_number: commented.issue_number}
+  result.remove("issue_number")
+  return result
 }
 
 fn __github_pr_checks(args, cfg) {
@@ -1955,7 +2122,26 @@ fn __github_actions_workflow_dispatch(args, cfg) {
     return repo
   }
   const r = unwrap(repo)
-  return __actions_workflow_dispatch(args + {owner: r.owner, repo: r.name}, cfg)
+  const workflow_id = args?.workflow_id ?? args?.workflow ?? args?.workflow_file
+  if workflow_id == nil || trim(to_string(workflow_id)) == "" {
+    return __err(
+      "schema_drift",
+      "github.actions.workflow_dispatch requires workflow_id, workflow, or workflow_file",
+    )
+  }
+  const ref = args?.ref ?? args?.branch ?? "main"
+  const resolved = github_dispatch_workflow_and_resolve_run(
+    r.owner,
+    r.name,
+    workflow_id,
+    ref,
+    args?.inputs ?? {},
+    args,
+  )
+  if !resolved.ok {
+    return Err(resolved?.error ?? {code: resolved.status, category: "workflow", message: resolved.status})
+  }
+  return __typed_workflow_dispatch(r.full_name, ref, resolved)
 }
 
 fn __github_actions_runs(args, cfg) {
@@ -1973,7 +2159,50 @@ fn __github_actions_run(args, cfg) {
     return repo
   }
   const r = unwrap(repo)
-  return __actions_workflow_run_get(args + {owner: r.owner, repo: r.name}, cfg)
+  const run = __actions_workflow_run_get(args + {owner: r.owner, repo: r.name}, cfg)
+  if is_err(run) {
+    return run
+  }
+  return __typed_workflow_run(r.full_name, run)
+}
+
+fn __github_actions_run_jobs(args, cfg) {
+  const repo = __repo_parts(args)
+  if is_err(repo) {
+    return repo
+  }
+  const r = unwrap(repo)
+  const response = __actions_workflow_run_jobs(args + {owner: r.owner, repo: r.name}, cfg)
+  if is_err(response) {
+    return response
+  }
+  if type_of(response?.jobs) != "list" || response?.total_count == nil {
+    return __err("invalid_response", "github.actions.run_jobs expected total_count and jobs")
+  }
+  let jobs = []
+  for job in response.jobs {
+    const typed = __typed_workflow_job(job)
+    if is_err(typed) {
+      return typed
+    }
+    jobs = jobs + [unwrap(typed)]
+  }
+  return {
+    repo: r.full_name,
+    run_id: __actions_run_id(args?.run_id),
+    total_count: to_int(response.total_count),
+    jobs: jobs,
+    page: if args?.page == nil {
+      1
+    } else {
+      to_int(args.page)
+    },
+    per_page: if args?.per_page == nil {
+      30
+    } else {
+      to_int(args.per_page)
+    },
+  }
 }
 
 fn __github_actions_logs(args, cfg) {
@@ -2044,23 +2273,16 @@ fn __github_release_latest(args, cfg) {
 fn __github_release_view(args, cfg) {
   const repo = __repo_parts(args)
   if is_err(repo) {
-    return __release_error_envelope(nil, unwrap_err(repo))
+    return repo
   }
   const r = unwrap(repo)
   const raw_tag = args?.tag
   if raw_tag == nil {
-    return __github_release_latest(args, cfg)
+    return __err("schema_drift", "github.release.view requires a non-empty exact tag")
   }
   const tag = trim(to_string(raw_tag))
   if tag == "" {
-    return __release_error_envelope(
-      r.full_name,
-      {
-        code: "schema_drift",
-        category: "schema_drift",
-        message: "github.release.view tag must be non-empty",
-      },
-    )
+    return __err("schema_drift", "github.release.view requires a non-empty exact tag")
   }
   const release = __github_json(
     "GET",
@@ -2072,9 +2294,98 @@ fn __github_release_view(args, cfg) {
     cfg,
   )
   if is_err(release) {
-    return __release_error_envelope(r.full_name, unwrap_err(release))
+    const error = unwrap_err(release)
+    if __is_status_error(error, 404) {
+      const access = __prove_repository_access(r, cfg)
+      if is_err(access) {
+        return access
+      }
+      return {repo: r.full_name, tag: tag, state: "absent", found: false, release: nil}
+    }
+    return release
   }
-  return __release_envelope(r.full_name, unwrap(release))
+  const typed = __typed_release(release)
+  if is_err(typed) {
+    return typed
+  }
+  return {repo: r.full_name, tag: tag, state: "found", found: true, release: unwrap(typed)}
+}
+
+fn __github_file_view(args, cfg) {
+  const repo = __repo_parts(args)
+  if is_err(repo) {
+    return repo
+  }
+  const r = unwrap(repo)
+  const path = __trim_leading_slash(args?.path ?? "")
+  const ref = trim(to_string(args?.ref ?? ""))
+  if path == "" || ref == "" {
+    return __err("schema_drift", "github.file.view requires a non-empty path and exact ref")
+  }
+  const content = __github_json(
+    "GET",
+    __github_api_url(
+      cfg.api_base_url,
+      "/repos/" + r.owner + "/" + r.name + "/contents/" + path + "?ref=" + url_encode(ref),
+    ),
+    nil,
+    cfg,
+  )
+  if is_err(content) {
+    const error = unwrap_err(content)
+    if __is_status_error(error, 404) {
+      const access = __prove_repository_access(r, cfg)
+      if is_err(access) {
+        return access
+      }
+      return {repo: r.full_name, path: path, ref: ref, state: "absent", found: false, file: nil}
+    }
+    return content
+  }
+  const file = __typed_repository_file(content, ref)
+  if is_err(file) {
+    return file
+  }
+  return {repo: r.full_name, path: path, ref: ref, state: "found", found: true, file: unwrap(file)}
+}
+
+fn __github_commit_signature(args, cfg) {
+  const repo = __repo_parts(args)
+  if is_err(repo) {
+    return repo
+  }
+  const r = unwrap(repo)
+  const ref = trim(to_string(args?.sha ?? args?.ref ?? ""))
+  if ref == "" {
+    return __err("schema_drift", "github.commit.signature requires sha or ref")
+  }
+  const commit = __github_json(
+    "GET",
+    __github_api_url(
+      cfg.api_base_url,
+      "/repos/" + r.owner + "/" + r.name + "/commits/" + url_encode(ref),
+    ),
+    nil,
+    cfg,
+  )
+  if is_err(commit) {
+    return commit
+  }
+  const verification = commit?.commit?.verification
+  if commit?.sha == nil || type_of(verification) != "dict" || type_of(verification?.verified) != "bool"
+    || trim(to_string(verification?.reason ?? "")) == "" {
+    return __err("invalid_response", "github.commit.signature response omitted verification evidence")
+  }
+  const result: GithubCommitSignature = {
+    repo: r.full_name,
+    sha: to_string(commit.sha),
+    verified: verification.verified,
+    reason: lowercase(to_string(verification.reason)),
+    signature_present: verification?.signature != nil && trim(to_string(verification.signature)) != "",
+    payload_present: verification?.payload != nil && trim(to_string(verification.payload)) != "",
+    verified_at: verification?.verified_at,
+  }
+  return result
 }
 
 fn __github_release_assets(args, cfg) {
@@ -2108,23 +2419,122 @@ fn __github_merge_queue_entries(args, cfg) {
   if branch == nil || trim(to_string(branch)) == "" {
     return __err("merge_queue", "github.merge_queue.entries requires branch or base_branch")
   }
+  const limit = to_int(args?.limit ?? args?.per_page ?? 100)
+  if limit == nil || limit < 1 || limit > 100 {
+    return __err("schema_drift", "github.merge_queue.entries limit must be from 1 to 100")
+  }
   const response = __github_json(
-    "GET",
-    __github_api_url(
-      cfg.api_base_url,
-      "/repos/" + r.owner + "/" + r.name + "/merge_queue/queues/" + url_encode(to_string(branch)),
-    ),
-    nil,
+    "POST",
+    __github_api_url(cfg.api_base_url, "/graphql"),
+    {
+      query: __merge_queue_entries_query(),
+      variables: {owner: r.owner, repo: r.name, branch: to_string(branch), limit: limit},
+    },
     cfg,
   )
   if is_err(response) {
-    return __err("merge_queue", unwrap_err(response)?.message ?? "failed to fetch merge queue entries")
+    return response
+  }
+  if response?.errors != nil && len(response.errors) > 0 {
+    return __err("graphql", "github merge queue query returned errors: " + json_stringify(response.errors))
+  }
+  const repository = response?.data?.repository
+  if type_of(repository) != "dict" {
+    return __err("invalid_response", "github merge queue response omitted repository evidence")
+  }
+  const queue = repository?.mergeQueue
+  if queue == nil {
+    return {repo: r.full_name, branch: to_string(branch), configured: false, url: nil, entries: []}
+  }
+  const nodes = queue?.entries?.nodes
+  if type_of(nodes) != "list" {
+    return __err("invalid_response", "github merge queue response omitted entries.nodes")
   }
   let entries = []
-  for entry in response?.entries ?? [] {
-    entries = entries + [__typed_merge_queue_entry(entry)]
+  for entry in nodes {
+    const typed = __typed_merge_queue_entry(entry)
+    if is_err(typed) {
+      return typed
+    }
+    entries = entries + [unwrap(typed)]
   }
-  return {repo: r.full_name, branch: branch, entries: entries}
+  return {
+    repo: r.full_name,
+    branch: to_string(branch),
+    configured: true,
+    url: to_string(queue?.url ?? ""),
+    entries: entries,
+  }
+}
+
+fn __github_merge_queue_membership(args, cfg) {
+  const repo = __repo_parts(args)
+  if is_err(repo) {
+    return repo
+  }
+  const r = unwrap(repo)
+  const number = args?.pr_number ?? args?.number ?? args?.pull_number
+  if number == nil {
+    return __err("schema_drift", "github.merge_queue.membership requires pr_number, number, or pull_number")
+  }
+  let pull = args?.pull
+  if pull == nil {
+    pull = __github_json(
+      "GET",
+      __github_api_url(
+        cfg.api_base_url,
+        "/repos/" + r.owner + "/" + r.name + "/pulls/" + to_string(number),
+      ),
+      nil,
+      cfg,
+    )
+    if is_err(pull) {
+      return pull
+    }
+  }
+  const valid = __validate_pull_identity(pull, "github.merge_queue.membership")
+  if is_err(valid) {
+    return valid
+  }
+  const response = __github_json(
+    "POST",
+    __github_api_url(cfg.api_base_url, "/graphql"),
+    {
+      query: __merge_queue_membership_query(),
+      variables: {owner: r.owner, repo: r.name, number: to_int(number)},
+    },
+    cfg,
+  )
+  if is_err(response) {
+    return response
+  }
+  if response?.errors != nil && len(response.errors) > 0 {
+    return __err(
+      "graphql",
+      "github merge queue membership returned errors: " + json_stringify(response.errors),
+    )
+  }
+  const node = response?.data?.repository?.pullRequest
+  if node?.number == nil || to_int(node.number) != to_int(number) {
+    return __err("invalid_response", "github merge queue membership omitted the requested pull request")
+  }
+  let entry = nil
+  if node?.mergeQueueEntry != nil {
+    const typed = __typed_merge_queue_entry(node.mergeQueueEntry)
+    if is_err(typed) {
+      return typed
+    }
+    entry = unwrap(typed)
+  }
+  return {
+    repo: r.full_name,
+    pull_number: to_int(number),
+    available: true,
+    queued: entry != nil,
+    auto_merge_armed: node?.autoMergeRequest != nil || pull?.auto_merge != nil,
+    entry: entry,
+    error: nil,
+  }
 }
 
 fn __github_merge_queue_enqueue(args, cfg) {
@@ -2137,45 +2547,65 @@ fn __github_merge_queue_enqueue(args, cfg) {
   if number == nil {
     return __err("merge_queue", "github.merge_queue.enqueue requires pr_number, number, or pull_number")
   }
-  let branch = args?.branch ?? args?.base_branch ?? args?.base
-  if branch == nil || trim(to_string(branch)) == "" {
-    const pull = __github_json(
-      "GET",
-      __github_api_url(
-        cfg.api_base_url,
-        "/repos/" + r.owner + "/" + r.name + "/pulls/" + to_string(number),
-      ),
-      nil,
-      cfg,
-    )
-    if is_err(pull) {
-      return pull
-    }
-    branch = pull?.base?.ref
+  const expected_head_oid = trim(to_string(args?.expected_head_oid ?? args?.expectedHeadOid ?? ""))
+  if expected_head_oid == "" {
+    return __err("schema_drift", "github.merge_queue.enqueue requires expected_head_oid")
   }
-  if branch == nil || trim(to_string(branch)) == "" {
-    return __err("merge_queue", "github.merge_queue.enqueue requires branch or a PR with base.ref")
-  }
-  const method = args?.method ?? args?.merge_method ?? "merge"
-  const response = __github_json(
-    "POST",
+  const pull = __github_json(
+    "GET",
     __github_api_url(
       cfg.api_base_url,
-      "/repos/" + r.owner + "/" + r.name + "/merge_queue/queues/" + url_encode(to_string(branch))
-        + "/items",
+      "/repos/" + r.owner + "/" + r.name + "/pulls/" + to_string(number),
     ),
-    {pull_number: number, merge_method: method, method: method, priority: args?.priority},
+    nil,
+    cfg,
+  )
+  if is_err(pull) {
+    return pull
+  }
+  const valid = __validate_pull_identity(pull, "github.merge_queue.enqueue")
+  if is_err(valid) {
+    return valid
+  }
+  if to_string(pull?.head?.sha ?? "") != expected_head_oid {
+    return __err(
+      "stale_head",
+      "pull request head no longer matches expected_head_oid",
+      {expected_head_oid: expected_head_oid, observed_head_oid: pull?.head?.sha},
+    )
+  }
+  if trim(to_string(pull?.node_id ?? "")) == "" {
+    return __err("invalid_response", "github.merge_queue.enqueue response omitted pull request node_id")
+  }
+  const response = __github_json(
+    "POST",
+    __github_api_url(cfg.api_base_url, "/graphql"),
+    {
+      query: __enqueue_pull_request_mutation(),
+      variables: {
+        input: {pullRequestId: pull.node_id, expectedHeadOid: expected_head_oid, jump: args?.jump ?? false},
+      },
+    },
     cfg,
   )
   if is_err(response) {
-    return __err("merge_queue", unwrap_err(response)?.message ?? "failed to enqueue PR in merge queue")
+    return response
+  }
+  if response?.errors != nil && len(response.errors) > 0 {
+    if __graphql_errors_indicate_stale_head(response.errors) {
+      return __err("stale_head", "GitHub rejected merge queue enqueue because the pull request head changed")
+    }
+    return __err("graphql", "github merge queue enqueue returned errors: " + json_stringify(response.errors))
+  }
+  const entry = __typed_merge_queue_entry(response?.data?.enqueuePullRequest?.mergeQueueEntry)
+  if is_err(entry) {
+    return entry
   }
   return {
     repo: r.full_name,
-    branch: branch,
-    pull_number: number,
-    requested_method: method,
-    entry: __typed_merge_queue_entry(response),
+    pull_number: to_int(number),
+    expected_head_oid: expected_head_oid,
+    entry: unwrap(entry),
   }
 }
 
@@ -2209,7 +2639,10 @@ fn __github_issue_comment(args, cfg) {
       "github issue comment helpers require issue_number, number, pr_number, or pull_number",
     )
   }
-  return __github_json(
+  if trim(to_string(args?.body ?? "")) == "" {
+    return __err("schema_drift", "github issue comment helpers require a non-empty body")
+  }
+  const comment = __github_json(
     "POST",
     __github_api_url(
       cfg.api_base_url,
@@ -2218,6 +2651,22 @@ fn __github_issue_comment(args, cfg) {
     {body: args?.body},
     cfg,
   )
+  if is_err(comment) {
+    return comment
+  }
+  if comment?.id == nil || comment?.body == nil {
+    return __err("invalid_response", "github comment response omitted id or body")
+  }
+  return {
+    repo: r.full_name,
+    issue_number: to_int(number),
+    id: comment.id,
+    body: to_string(comment.body),
+    url: to_string(comment?.html_url ?? comment?.url ?? ""),
+    user: __typed_user(comment?.user),
+    created_at: comment?.created_at,
+    updated_at: comment?.updated_at,
+  }
 }
 
 fn __github_branch_protection(args, cfg) {
@@ -2373,6 +2822,13 @@ fn __pulls_merge_safe(args, cfg) {
 }
 
 fn __pulls_enable_auto_merge(args, cfg) {
+  const expected_head_oid = trim(to_string(args?.expected_head_oid ?? args?.expectedHeadOid ?? ""))
+  if expected_head_oid == "" {
+    return __err(
+      "schema_drift",
+      "github.pr.enable_auto_merge requires expected_head_oid as an explicit publication lease",
+    )
+  }
   const pull = __github_json(
     "GET",
     __github_api_url(
@@ -2385,22 +2841,37 @@ fn __pulls_enable_auto_merge(args, cfg) {
   if is_err(pull) {
     return pull
   }
+  const valid = __validate_pull_identity(pull, "github.pr.enable_auto_merge")
+  if is_err(valid) {
+    return valid
+  }
+  const observed_head_oid = trim(to_string(pull?.head?.sha ?? ""))
+  if observed_head_oid != expected_head_oid {
+    return __err(
+      "stale_head",
+      "pull request head no longer matches expected_head_oid",
+      {expected_head_oid: expected_head_oid, observed_head_oid: observed_head_oid},
+    )
+  }
+  const method = __graphql_merge_method(args?.method ?? args?.merge_method ?? "MERGE")
+  if is_err(method) {
+    return method
+  }
   if pull?.auto_merge != nil {
     return {
       repo: to_string(args.owner) + "/" + to_string(args.repo),
       pull_number: args.pull_number,
       state: "already_enabled",
-      auto_merge: pull.auto_merge,
-      pull_request: pull,
+      already_enabled: true,
+      expected_head_oid: expected_head_oid,
+      observed_head_oid: observed_head_oid,
+      merge_method: uppercase(to_string(pull?.auto_merge?.merge_method ?? unwrap(method))),
+      url: to_string(pull?.html_url ?? pull?.url ?? ""),
     }
   }
   const node_id = pull?.node_id
   if node_id == nil || trim(to_string(node_id)) == "" {
     return __err("schema_drift", "GitHub PR response did not include node_id for auto-merge")
-  }
-  const method = __graphql_merge_method(args?.method ?? args?.merge_method ?? "MERGE")
-  if is_err(method) {
-    return method
   }
   const graph = __github_json(
     "POST",
@@ -2412,7 +2883,7 @@ fn __pulls_enable_auto_merge(args, cfg) {
         mergeMethod: unwrap(method),
         commitHeadline: args?.commit_headline ?? args?.commit_title,
         commitBody: args?.commit_body ?? args?.commit_message,
-        expectedHeadOid: args?.expected_head_oid ?? args?.expectedHeadOid ?? pull?.head?.sha,
+        expectedHeadOid: expected_head_oid,
       },
     },
     cfg,
@@ -2421,17 +2892,29 @@ fn __pulls_enable_auto_merge(args, cfg) {
     return graph
   }
   if graph?.errors != nil && len(graph.errors) > 0 {
+    if __graphql_errors_indicate_stale_head(graph.errors) {
+      return __err(
+        "stale_head",
+        "GitHub rejected auto-merge because the pull request head changed",
+        {expected_head_oid: expected_head_oid, observed_head_oid: observed_head_oid},
+      )
+    }
     return __err("graphql", "github GraphQL returned errors: " + json_stringify(graph.errors))
   }
-  const enabled = graph?.data?.enablePullRequestAutoMerge ?? {}
+  const enabled = graph?.data?.enablePullRequestAutoMerge
+  const enabled_pull = enabled?.pullRequest
+  if enabled_pull?.number == nil || enabled_pull?.autoMergeRequest == nil {
+    return __err("invalid_response", "GitHub auto-merge response omitted pull request evidence")
+  }
   return {
     repo: to_string(args.owner) + "/" + to_string(args.repo),
     pull_number: args.pull_number,
     state: "enabled",
-    requested_method: unwrap(method),
-    pull_request: enabled?.pullRequest,
-    actor: enabled?.actor,
-    raw: enabled,
+    already_enabled: false,
+    expected_head_oid: expected_head_oid,
+    observed_head_oid: observed_head_oid,
+    merge_method: uppercase(to_string(enabled_pull?.autoMergeRequest?.mergeMethod ?? unwrap(method))),
+    url: to_string(enabled_pull?.url ?? pull?.html_url ?? ""),
   }
 }
 
@@ -3068,6 +3551,82 @@ mutation HarnGithubConnectorEnableAutoMerge($pullRequestId: ID!, $mergeMethod: P
 """
 }
 
+fn __merge_queue_entries_query() {
+  return """
+query HarnGithubConnectorMergeQueueEntries($owner: String!, $repo: String!, $branch: String!, $limit: Int!) {
+  repository(owner: $owner, name: $repo) {
+    mergeQueue(branch: $branch) {
+      url
+      entries(first: $limit) {
+        nodes {
+          id
+          position
+          state
+          enqueuedAt
+          jump
+          solo
+          estimatedTimeToMerge
+          headCommit { oid }
+          pullRequest { number url headRefOid baseRefName }
+        }
+      }
+    }
+  }
+}
+"""
+}
+
+fn __merge_queue_membership_query() {
+  return """
+query HarnGithubConnectorMergeQueueMembership($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      number
+      autoMergeRequest { enabledAt mergeMethod }
+      mergeQueueEntry {
+        id
+        position
+        state
+        enqueuedAt
+        jump
+        solo
+        estimatedTimeToMerge
+        headCommit { oid }
+        pullRequest { number url headRefOid baseRefName }
+      }
+    }
+  }
+}
+"""
+}
+
+fn __enqueue_pull_request_mutation() {
+  return """
+mutation HarnGithubConnectorEnqueuePullRequest($input: EnqueuePullRequestInput!) {
+  enqueuePullRequest(input: $input) {
+    mergeQueueEntry {
+      id
+      position
+      state
+      enqueuedAt
+      jump
+      solo
+      estimatedTimeToMerge
+      headCommit { oid }
+      pullRequest { number url headRefOid baseRefName }
+    }
+  }
+}
+"""
+}
+
+fn __graphql_errors_indicate_stale_head(errors) {
+  const message = lowercase(json_stringify(errors ?? []))
+  return contains(message, "expected head") || contains(message, "expectedheadoid")
+    || contains(message, "head oid")
+    || contains(message, "head sha")
+}
+
 fn __github_create_signed_commit(args, cfg) {
   const owner = trim(to_string(args?.owner ?? ""))
   const repo = trim(to_string(args?.repo ?? ""))
@@ -3337,8 +3896,8 @@ fn __github_branch_protection_raw(repo, branch, cfg) {
 }
 
 fn __typed_pr_summary(pull) {
-  const state = __classify_pr_state(pull, nil, pull?.auto_merge)
-  return {
+  const state = __classify_pr_state(pull, nil, nil)
+  const summary: GithubPullRequestSummary = {
     repo: pull?.base?.repo?.full_name ?? "",
     number: pull?.number,
     title: pull?.title ?? "",
@@ -3352,11 +3911,13 @@ fn __typed_pr_summary(pull) {
     base: __typed_ref(pull?.base),
     head: __typed_ref(pull?.head),
     labels: __label_names(pull?.labels ?? []),
-    in_merge_queue: pull?.auto_merge != nil,
+    auto_merge_armed: pull?.auto_merge != nil,
+    in_merge_queue: nil,
   }
+  return summary
 }
 
-fn __typed_pr_view(pull, protection) {
+fn __typed_pr_details(pull) {
   return __typed_pr_summary(pull)
     + {
     body: pull?.body ?? "",
@@ -3365,9 +3926,27 @@ fn __typed_pr_view(pull, protection) {
     updated_at: pull?.updated_at,
     closed_at: pull?.closed_at,
     merged_at: pull?.merged_at,
-    branch_protection: __branch_protection_summary(protection, pull?.base?.ref),
-    raw: pull,
   }
+}
+
+fn __typed_pr_view(pull, protection, queue) {
+  let summary = __typed_pr_details(pull)
+  summary["auto_merge_armed"] = queue.auto_merge_armed
+  summary["in_merge_queue"] = if queue.available {
+    queue.queued
+  } else {
+    nil
+  }
+  summary["state"] = __classify_pr_state(
+    pull,
+    nil,
+    if queue.available {
+      queue.entry
+    } else {
+      nil
+    },
+  )
+  return summary + {branch_protection: protection, queue_membership: queue}
 }
 
 fn __typed_pr_edit(pull) {
@@ -3383,11 +3962,217 @@ fn __typed_ref(ref) {
   }
 }
 
-fn __typed_user(user) {
+fn __typed_user(user) -> GithubPullRequestUser? {
   if user == nil {
     return nil
   }
   return {id: user?.id, login: user?.login ?? "", type: user?.type ?? ""}
+}
+
+fn __validate_pull_response(pull, surface) {
+  if type_of(pull) != "dict" || pull?.number == nil || trim(to_string(pull?.title ?? "")) == ""
+    || trim(to_string(pull?.state ?? "")) == ""
+    || trim(to_string(pull?.base?.ref ?? "")) == ""
+    || trim(to_string(pull?.head?.ref ?? "")) == ""
+    || trim(to_string(pull?.head?.sha ?? "")) == "" {
+    return __err("invalid_response", surface + " response omitted required pull-request fields")
+  }
+  return Ok(true)
+}
+
+fn __validate_pull_identity(pull, surface) {
+  if type_of(pull) != "dict" || pull?.number == nil || trim(to_string(pull?.head?.sha ?? "")) == "" {
+    return __err("invalid_response", surface + " response omitted pull number or head sha")
+  }
+  return Ok(true)
+}
+
+fn __typed_pr_file(file) {
+  if type_of(file) != "dict" || trim(to_string(file?.sha ?? "")) == ""
+    || trim(to_string(file?.filename ?? "")) == ""
+    || trim(to_string(file?.status ?? "")) == ""
+    || file?.additions == nil
+    || file?.deletions == nil
+    || file?.changes == nil {
+    return __err("invalid_response", "github.pr.files entry omitted required file evidence")
+  }
+  const typed: GithubPullRequestFile = {
+    sha: to_string(file.sha),
+    filename: to_string(file.filename),
+    status: lowercase(to_string(file.status)),
+    additions: to_int(file.additions),
+    deletions: to_int(file.deletions),
+    changes: to_int(file.changes),
+    previous_filename: file?.previous_filename,
+    blob_url: file?.blob_url,
+    raw_url: file?.raw_url,
+    contents_url: file?.contents_url,
+  }
+  return Ok(typed)
+}
+
+fn __typed_release(release) {
+  if type_of(release) != "dict" || release?.id == nil || trim(to_string(release?.tag_name ?? "")) == "" {
+    return __err("invalid_response", "github.release.view response omitted release id or tag")
+  }
+  let assets = []
+  for asset in release?.assets ?? [] {
+    if asset?.id == nil || trim(to_string(asset?.name ?? "")) == "" {
+      return __err("invalid_response", "github.release.view response contained a malformed asset")
+    }
+    assets = assets
+      + [
+      {
+        id: asset.id,
+        name: to_string(asset.name),
+        size: to_int(asset?.size ?? 0),
+        state: to_string(asset?.state ?? ""),
+        content_type: to_string(asset?.content_type ?? ""),
+        download_count: to_int(asset?.download_count ?? 0),
+        url: to_string(asset?.browser_download_url ?? asset?.url ?? ""),
+        created_at: asset?.created_at,
+        updated_at: asset?.updated_at,
+      },
+    ]
+  }
+  return Ok(
+    {
+      id: release.id,
+      tag_name: to_string(release.tag_name),
+      name: to_string(release?.name ?? ""),
+      draft: release?.draft ?? false,
+      prerelease: release?.prerelease ?? false,
+      url: to_string(release?.html_url ?? release?.url ?? ""),
+      target_commitish: to_string(release?.target_commitish ?? ""),
+      published_at: release?.published_at,
+      assets: assets,
+    },
+  )
+}
+
+fn __typed_repository_file(content, ref) {
+  if type_of(content) != "dict" || content?.type != "file" || content?.encoding != "base64"
+    || trim(to_string(content?.path ?? "")) == ""
+    || trim(to_string(content?.sha ?? "")) == ""
+    || content?.content == nil {
+    return __err("invalid_response", "github.file.view expected one base64-encoded file")
+  }
+  const decoded = try {
+    base64_decode(to_string(content.content).replace("\n", ""))
+  }
+  if is_err(decoded) {
+    return __err("invalid_response", "github.file.view could not decode GitHub file content")
+  }
+  return Ok(
+    {
+      name: to_string(content?.name ?? ""),
+      path: to_string(content.path),
+      sha: to_string(content.sha),
+      size: to_int(content?.size ?? 0),
+      ref: ref,
+      text: unwrap(decoded),
+      url: to_string(content?.html_url ?? content?.url ?? ""),
+    },
+  )
+}
+
+fn __typed_workflow_dispatch(repo, ref, resolved) {
+  if resolved?.run_id == nil || trim(to_string(resolved?.head_sha ?? "")) == ""
+    || trim(to_string(resolved?.event ?? "")) == ""
+    || trim(to_string(resolved?.run_url ?? "")) == "" {
+    return __err("invalid_response", "github.actions.workflow_dispatch could not prove an exact run identity")
+  }
+  return {
+    repo: repo,
+    accepted: true,
+    run_id: to_int(resolved.run_id),
+    workflow_id: resolved.workflow_id,
+    ref: to_string(ref),
+    head_sha: to_string(resolved.head_sha),
+    head_branch: to_string(resolved?.head_branch ?? ""),
+    event: to_string(resolved.event),
+    url: to_string(resolved.run_url),
+    created_at: resolved?.created_at,
+  }
+}
+
+fn __typed_workflow_run(repo, run) {
+  if type_of(run) != "dict" || run?.id == nil || trim(to_string(run?.status ?? "")) == ""
+    || trim(to_string(run?.event ?? "")) == ""
+    || trim(to_string(run?.head_sha ?? "")) == "" {
+    return __err("invalid_response", "github.actions.run response omitted exact run evidence")
+  }
+  return {
+    repo: repo,
+    id: to_int(run.id),
+    workflow_id: run?.workflow_id,
+    run_number: run?.run_number,
+    run_attempt: run?.run_attempt,
+    name: to_string(run?.name ?? ""),
+    event: to_string(run.event),
+    status: lowercase(to_string(run.status)),
+    conclusion: if run?.conclusion == nil {
+      nil
+    } else {
+      lowercase(to_string(run.conclusion))
+    },
+    head_branch: to_string(run?.head_branch ?? ""),
+    head_sha: to_string(run.head_sha),
+    url: to_string(run?.html_url ?? run?.url ?? ""),
+    created_at: run?.created_at,
+    run_started_at: run?.run_started_at,
+    updated_at: run?.updated_at,
+  }
+}
+
+fn __typed_workflow_job(job) {
+  if type_of(job) != "dict" || job?.id == nil || job?.run_id == nil
+    || trim(to_string(job?.name ?? "")) == ""
+    || trim(to_string(job?.status ?? "")) == ""
+    || type_of(job?.steps ?? []) != "list" {
+    return __err("invalid_response", "github.actions.run_jobs response contained a malformed job")
+  }
+  let steps = []
+  for step in job?.steps ?? [] {
+    if step?.number == nil || trim(to_string(step?.name ?? "")) == ""
+      || trim(to_string(step?.status ?? "")) == "" {
+      return __err("invalid_response", "github.actions.run_jobs response contained a malformed step")
+    }
+    steps = steps
+      + [
+      {
+        number: to_int(step.number),
+        name: to_string(step.name),
+        status: lowercase(to_string(step.status)),
+        conclusion: if step?.conclusion == nil {
+          nil
+        } else {
+          lowercase(to_string(step.conclusion))
+        },
+        started_at: step?.started_at,
+        completed_at: step?.completed_at,
+      },
+    ]
+  }
+  return Ok(
+    {
+      id: to_int(job.id),
+      run_id: to_int(job.run_id),
+      name: to_string(job.name),
+      status: lowercase(to_string(job.status)),
+      conclusion: if job?.conclusion == nil {
+        nil
+      } else {
+        lowercase(to_string(job.conclusion))
+      },
+      head_sha: to_string(job?.head_sha ?? ""),
+      url: to_string(job?.html_url ?? job?.url ?? ""),
+      runner_name: to_string(job?.runner_name ?? ""),
+      started_at: job?.started_at,
+      completed_at: job?.completed_at,
+      steps: steps,
+    },
+  )
 }
 
 fn __label_names(labels) {
@@ -3400,10 +4185,23 @@ fn __label_names(labels) {
 
 fn __branch_protection_summary(protection, branch) {
   if protection == nil {
-    return {branch: branch, protected: false, required_checks: [], strict: false, raw: nil}
+    return {
+      available: true,
+      branch: to_string(branch ?? ""),
+      protected: false,
+      required_checks: [],
+      strict: false,
+      required_review_count: 0,
+      require_code_owner_reviews: false,
+      require_conversation_resolution: false,
+      allow_force_pushes: false,
+      allow_deletions: false,
+      error: nil,
+    }
   }
   return {
-    branch: branch,
+    available: true,
+    branch: to_string(branch ?? ""),
     protected: true,
     required_checks: protection?.required_status_checks?.contexts ?? [],
     strict: protection?.required_status_checks?.strict ?? false,
@@ -3412,7 +4210,35 @@ fn __branch_protection_summary(protection, branch) {
     require_conversation_resolution: protection?.required_conversation_resolution?.enabled ?? false,
     allow_force_pushes: protection?.allow_force_pushes?.enabled ?? false,
     allow_deletions: protection?.allow_deletions?.enabled ?? false,
-    raw: protection,
+    error: nil,
+  }
+}
+
+fn __branch_protection_unavailable(branch, error) {
+  return {
+    available: false,
+    branch: to_string(branch ?? ""),
+    protected: nil,
+    required_checks: [],
+    strict: nil,
+    required_review_count: nil,
+    require_code_owner_reviews: nil,
+    require_conversation_resolution: nil,
+    allow_force_pushes: nil,
+    allow_deletions: nil,
+    error: error,
+  }
+}
+
+fn __queue_membership_unavailable(repo, number, error, auto_merge_armed) {
+  return {
+    repo: repo,
+    pull_number: to_int(number),
+    available: false,
+    queued: false,
+    auto_merge_armed: auto_merge_armed,
+    entry: nil,
+    error: error,
   }
 }
 
@@ -3437,7 +4263,6 @@ fn __typed_check_run(run) {
     details_url: run?.details_url ?? run?.detailsUrl,
     html_url: run?.html_url,
     external_id: run?.external_id,
-    raw: run,
   }
 }
 
@@ -3490,7 +4315,7 @@ fn __classify_pr_state(pull, rollup, queue) {
   if pull?.state == "closed" && pull?.merged_at != nil {
     return "merged"
   }
-  if queue != nil || pull?.auto_merge != nil {
+  if queue != nil {
     return "queued"
   }
   if !(pull?.mergeable ?? true) || lowercase(pull?.mergeable_state ?? "") == "dirty" {
@@ -3509,13 +4334,26 @@ fn __classify_pr_state(pull, rollup, queue) {
 }
 
 fn __typed_merge_queue_entry(entry) {
-  return {
-    pull_number: entry?.pull_request_number ?? entry?.pull_number ?? entry?.number,
-    status: entry?.status ?? "unknown",
-    head_branch: entry?.head_branch,
-    priority: entry?.priority,
-    raw: entry,
+  if type_of(entry) != "dict" || trim(to_string(entry?.id ?? "")) == ""
+    || entry?.pullRequest?.number == nil
+    || entry?.position == nil
+    || trim(to_string(entry?.state ?? "")) == "" {
+    return __err("invalid_response", "github merge queue entry omitted required evidence")
   }
+  const typed: GithubMergeQueueEntry = {
+    id: to_string(entry.id),
+    pull_number: to_int(entry.pullRequest.number),
+    url: to_string(entry?.pullRequest?.url ?? ""),
+    state: lowercase(to_string(entry.state)),
+    position: to_int(entry.position),
+    enqueued_at: entry?.enqueuedAt,
+    head_sha: to_string(entry?.headCommit?.oid ?? entry?.pullRequest?.headRefOid ?? ""),
+    base_branch: to_string(entry?.pullRequest?.baseRefName ?? ""),
+    jump: entry?.jump ?? false,
+    solo: entry?.solo ?? false,
+    estimated_time_to_merge_seconds: entry?.estimatedTimeToMerge,
+  }
+  return Ok(typed)
 }
 
 fn __extract_actions_run_id(url) {
@@ -3557,7 +4395,8 @@ fn __duration_seconds(started_at, completed_at) {
 }
 
 fn __is_status_error(err, status) {
-  return contains(to_string(err?.message ?? ""), "status " + to_string(status))
+  return to_int(err?.http_status ?? 0) == status
+    || contains(to_string(err?.message ?? ""), "status " + to_string(status))
 }
 
 fn __merge_body(args, pull) {
@@ -3729,6 +4568,9 @@ fn __error_category(code) {
   }
   if code == "schema_drift" || code == "invalid_response" || code == "invalid_json" {
     return "schema_drift"
+  }
+  if code == "stale_head" {
+    return "conflict"
   }
   return code
 }
@@ -5510,6 +6352,8 @@ fn __config_keys() {
     "backoff_ms",
     "cap_ms",
     "respect_retry_after",
+    "poll_interval_ms",
+    "max_wait_ms",
     "allow_gh_auth_fallback",
     "gh_auth_fallback",
     "gh_token",
@@ -6134,6 +6978,22 @@ fn __release_assets_envelope(repo, release_id, assets) {
 
 fn __release_assets_error_envelope(repo, release_id, error) {
   return {ok: false, repo: repo, release_id: release_id, assets: [], asset_names: [], raw: nil, error: error}
+}
+
+fn __prove_repository_access(repo, cfg) {
+  const visible = __github_json(
+    "GET",
+    __github_api_url(cfg.api_base_url, "/repos/" + repo.owner + "/" + repo.name),
+    nil,
+    cfg,
+  )
+  if is_err(visible) {
+    return visible
+  }
+  if lowercase(trim(to_string(visible?.full_name ?? ""))) != lowercase(repo.owner + "/" + repo.name) {
+    return __err("invalid_response", "GitHub repository access proof omitted full_name")
+  }
+  return Ok(true)
 }
 
 @complexity(allow)

--- a/src/pr_edit.harn
+++ b/src/pr_edit.harn
@@ -61,6 +61,5 @@ pub fn pr_edit_result(summary: dict, pull: dict) -> dict {
     updated_at: pull?.updated_at,
     closed_at: pull?.closed_at,
     merged_at: pull?.merged_at,
-    raw: pull,
   }
 }

--- a/tests/north_star_contracts.harn
+++ b/tests/north_star_contracts.harn
@@ -1,0 +1,537 @@
+import { call } from "../src/lib"
+
+const BASE = "https://github-api.test"
+
+fn auth() {
+  return {api_base_url: BASE, installation_token: "test-token", poll_interval_ms: 0, max_attempts: 2}
+}
+
+fn pull(number, sha, auto_merge = nil) {
+  return {
+    number: number,
+    node_id: "PR_" + to_string(number),
+    title: "PR " + to_string(number),
+    body: "body",
+    state: "open",
+    html_url: "https://github.com/octo-org/octo-repo/pull/" + to_string(number),
+    mergeable: true,
+    mergeable_state: "clean",
+    auto_merge: auto_merge,
+    base: {ref: "main", sha: "base-sha", repo: {full_name: "octo-org/octo-repo", owner: {login: "octo-org"}}},
+    head: {
+      ref: "feature/" + to_string(number),
+      sha: sha,
+      repo: {full_name: "octo-org/octo-repo", owner: {login: "octo-org"}},
+    },
+    labels: [],
+  }
+}
+
+fn queue_entry(number, sha) {
+  return {
+    id: "MQE_" + to_string(number),
+    position: 2,
+    state: "AWAITING_CHECKS",
+    enqueuedAt: "2026-07-13T12:00:00Z",
+    jump: false,
+    solo: false,
+    estimatedTimeToMerge: 90,
+    headCommit: {oid: sha},
+    pullRequest: {
+      number: number,
+      url: "https://github.com/octo-org/octo-repo/pull/" + to_string(number),
+      headRefOid: sha,
+      baseRefName: "main",
+    },
+  }
+}
+
+pipeline test_pr_create_files_and_comment_are_closed_records(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  http_mock(
+    "POST",
+    BASE + "/repos/octo-org/octo-repo/pulls",
+    {status: 201, body: json_stringify(pull(41, "head-41")), headers: {"x-ratelimit-remaining": "20"}},
+  )
+  const created = call(
+    "github.pr.create",
+    auth()
+      + {
+      repo: "octo-org/octo-repo",
+      title: "PR 41",
+      head: "feature/41",
+      base: "main",
+      body: "body",
+      draft: true,
+    },
+  )
+  assert_eq(created.number, 41, "created PR is normalized")
+  assert_eq(created.created, true, "creation receipt is explicit")
+  assert_eq(created.head.sha, "head-41", "created PR retains head evidence")
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/pulls/41/files?per_page=50&page=2",
+    {
+      status: 200,
+      body: json_stringify(
+        [
+          {
+            sha: "blob-sha",
+            filename: "src/lib.harn",
+            status: "modified",
+            additions: 10,
+            deletions: 2,
+            changes: 12,
+            blob_url: "https://github.com/blob/blob-sha",
+          },
+        ],
+      ),
+      headers: {"x-ratelimit-remaining": "19"},
+    },
+  )
+  const files = call("github.pr.files", auth() + {repo: "octo-org/octo-repo", number: 41, per_page: 50, page: 2})
+  assert_eq(files.files[0].filename, "src/lib.harn", "file path is normalized")
+  assert_eq(files.files[0].changes, 12, "file counts are retained")
+  http_mock(
+    "POST",
+    BASE + "/repos/octo-org/octo-repo/issues/41/comments",
+    {
+      status: 201,
+      body: json_stringify(
+        {
+          id: 901,
+          body: "ready",
+          html_url: "https://github.com/octo-org/octo-repo/pull/41#issuecomment-901",
+          user: {id: 7, login: "octocat", type: "User"},
+          created_at: "2026-07-13T12:01:00Z",
+          updated_at: "2026-07-13T12:01:00Z",
+        },
+      ),
+      headers: {"x-ratelimit-remaining": "18"},
+    },
+  )
+  const comment = call("github.pr.comment", auth() + {repo: "octo-org/octo-repo", number: 41, body: "ready"})
+  assert_eq(comment.pull_number, 41, "comment retains PR number")
+  assert_eq(comment.user.login, "octocat", "comment actor is normalized")
+}
+
+pipeline test_pr_view_survives_missing_branch_admin_permission_and_armed_is_not_queued(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/pulls/42",
+    {
+      status: 200,
+      body: json_stringify(pull(42, "head-42", {merge_method: "SQUASH"})),
+      headers: {"x-ratelimit-remaining": "20"},
+    },
+  )
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/branches/main/protection",
+    {
+      status: 403,
+      body: json_stringify({message: "Resource not accessible by integration"}),
+      headers: {"x-ratelimit-remaining": "19"},
+    },
+  )
+  http_mock(
+    "POST",
+    BASE + "/graphql",
+    {
+      status: 200,
+      body: json_stringify(
+        {
+          data: {
+            repository: {
+              pullRequest: {
+                number: 42,
+                autoMergeRequest: {enabledAt: "2026-07-13T12:00:00Z", mergeMethod: "SQUASH"},
+                mergeQueueEntry: nil,
+              },
+            },
+          },
+        },
+      ),
+      headers: {"x-ratelimit-remaining": "18"},
+    },
+  )
+  const viewed = call("github.pr.view", auth() + {repo: "octo-org/octo-repo", number: 42})
+  assert_eq(viewed.number, 42, "base PR read succeeds")
+  assert_eq(viewed.branch_protection.available, false, "admin-only enrichment is marked unavailable")
+  assert_eq(viewed.branch_protection.error.code, "missing_scopes", "permission evidence is retained")
+  assert_eq(viewed.auto_merge_armed, true, "auto-merge state is retained")
+  assert_eq(viewed.in_merge_queue, false, "armed PR is not reported queued")
+  assert_eq(viewed.state, "green", "armed PR is not classified as queued")
+}
+
+pipeline test_merge_queue_membership_uses_queue_entry_evidence(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/pulls/43",
+    {status: 200, body: json_stringify(pull(43, "head-43")), headers: {"x-ratelimit-remaining": "20"}},
+  )
+  http_mock(
+    "POST",
+    BASE + "/graphql",
+    {
+      status: 200,
+      body: json_stringify(
+        {
+          data: {
+            repository: {pullRequest: {number: 43, autoMergeRequest: nil, mergeQueueEntry: queue_entry(43, "head-43")}},
+          },
+        },
+      ),
+      headers: {"x-ratelimit-remaining": "19"},
+    },
+  )
+  const membership = call("github.merge_queue.membership", auth() + {repo: "octo-org/octo-repo", number: 43})
+  assert_eq(membership.queued, true, "queue entry proves membership")
+  assert_eq(membership.entry.pull_number, 43, "membership returns the exact entry")
+  assert_eq(membership.entry.state, "awaiting_checks", "wire enum is normalized once")
+}
+
+pipeline test_auto_merge_rejects_stale_expected_head_before_mutation(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const missing = call(
+    "github.pr.enable_auto_merge",
+    auth() + {repo: "octo-org/octo-repo", number: 44, method: "squash"},
+  )
+  assert(is_err(missing), "missing head lease fails closed")
+  assert_eq(unwrap_err(missing).code, "schema_drift", "head lease is required")
+  assert_eq(len(http_mock_calls()), 0, "missing lease performs no I/O")
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/pulls/44",
+    {status: 200, body: json_stringify(pull(44, "new-head")), headers: {"x-ratelimit-remaining": "20"}},
+  )
+  const result = call(
+    "github.pr.enable_auto_merge",
+    auth()
+      + {repo: "octo-org/octo-repo", number: 44, expected_head_oid: "old-head", method: "squash"},
+  )
+  assert(is_err(result), "stale head fails closed")
+  assert_eq(unwrap_err(result).code, "stale_head", "stale lease has a stable error code")
+  assert_eq(unwrap_err(result).observed_head_oid, "new-head", "observed head is reported")
+  assert_eq(len(http_mock_calls()), 1, "stale lease performs no mutation")
+}
+
+pipeline test_commit_signature_states_are_normalized(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/commits/verified",
+    {
+      status: 200,
+      body: json_stringify(
+        {
+          sha: "verified-sha",
+          commit: {
+            verification: {
+              verified: true,
+              reason: "valid",
+              signature: "signature",
+              payload: "payload",
+              verified_at: "2026-07-13T12:00:00Z",
+            },
+          },
+        },
+      ),
+      headers: {"x-ratelimit-remaining": "20"},
+    },
+  )
+  const verified = call("github.commit.signature", auth() + {repo: "octo-org/octo-repo", ref: "verified"})
+  assert_eq(verified.verified, true, "valid signature is verified")
+  assert_eq(verified.signature_present, true, "signature material is present")
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/commits/unsigned",
+    {
+      status: 200,
+      body: json_stringify(
+        {
+          sha: "unsigned-sha",
+          commit: {
+            verification: {verified: false, reason: "unsigned", signature: nil, payload: nil, verified_at: nil},
+          },
+        },
+      ),
+      headers: {"x-ratelimit-remaining": "19"},
+    },
+  )
+  const unsigned = call("github.commit.signature", auth() + {repo: "octo-org/octo-repo", ref: "unsigned"})
+  assert_eq(unsigned.verified, false, "unsigned is evidence, not transport failure")
+  assert_eq(unsigned.reason, "unsigned", "unsigned reason is retained")
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/commits/invalid",
+    {
+      status: 200,
+      body: json_stringify(
+        {
+          sha: "invalid-sha",
+          commit: {
+            verification: {verified: false, reason: "bad_email", signature: "signature", payload: "payload", verified_at: nil},
+          },
+        },
+      ),
+      headers: {"x-ratelimit-remaining": "18"},
+    },
+  )
+  const invalid = call("github.commit.signature", auth() + {repo: "octo-org/octo-repo", ref: "invalid"})
+  assert_eq(invalid.reason, "bad_email", "invalid signature reason is retained")
+  assert_eq(invalid.signature_present, true, "invalid signature still reports material")
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/commits/malformed",
+    {
+      status: 200,
+      body: json_stringify({sha: "malformed-sha", commit: {verification: {verified: false}}}),
+      headers: {"x-ratelimit-remaining": "17"},
+    },
+  )
+  const malformed = call("github.commit.signature", auth() + {repo: "octo-org/octo-repo", ref: "malformed"})
+  assert(is_err(malformed), "malformed signature payload fails closed")
+  assert_eq(unwrap_err(malformed).code, "invalid_response", "signature shape is validated once")
+}
+
+pipeline test_exact_file_lookup_separates_absence_from_inaccessibility(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/contents/VERSION?ref=main",
+    {
+      responses: [
+        {
+          status: 200,
+          body: json_stringify(
+            {
+              type: "file",
+              encoding: "base64",
+              name: "VERSION",
+              path: "VERSION",
+              sha: "file-sha",
+              size: 7,
+              content: base64_encode("0.4.0\n"),
+              html_url: "https://github.com/octo-org/octo-repo/blob/main/VERSION",
+            },
+          ),
+          headers: {"x-ratelimit-remaining": "20"},
+        },
+        {
+          status: 404,
+          body: json_stringify({message: "Not Found"}),
+          headers: {"x-ratelimit-remaining": "19"},
+        },
+        {
+          status: 404,
+          body: json_stringify({message: "Not Found"}),
+          headers: {"x-ratelimit-remaining": "17"},
+        },
+      ],
+    },
+  )
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo",
+    {
+      responses: [
+        {
+          status: 200,
+          body: json_stringify({full_name: "octo-org/octo-repo"}),
+          headers: {"x-ratelimit-remaining": "18"},
+        },
+        {
+          status: 404,
+          body: json_stringify({message: "Not Found"}),
+          headers: {"x-ratelimit-remaining": "16"},
+        },
+      ],
+    },
+  )
+  const found = call("github.file.view", auth() + {repo: "octo-org/octo-repo", path: "VERSION", ref: "main"})
+  assert_eq(found.file.text, "0.4.0\n", "found file is decoded")
+  const absent = call("github.file.view", auth() + {repo: "octo-org/octo-repo", path: "VERSION", ref: "main"})
+  assert_eq(absent.state, "absent", "accessible repository proves absence")
+  const inaccessible = call("github.file.view", auth() + {repo: "octo-org/octo-repo", path: "VERSION", ref: "main"})
+  assert(is_err(inaccessible), "masked private-resource 404 is not absence")
+  assert_eq(
+    unwrap_err(inaccessible).code,
+    "inaccessible_resource",
+    "masked 404 remains permission failure",
+  )
+}
+
+pipeline test_canonical_http_failures_and_malformed_payloads_fail_closed(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const cases = [
+    {path: "unauthorized", status: 401, code: "auth", message: "Bad credentials", headers: {}},
+    {
+      path: "forbidden",
+      status: 403,
+      code: "missing_scopes",
+      message: "Resource not accessible by integration",
+      headers: {},
+    },
+    {path: "limited", status: 429, code: "rate_limited", message: "rate limit exceeded", headers: {}},
+    {path: "server", status: 500, code: "network", message: "server error", headers: {}},
+  ]
+  for item in cases {
+    http_mock(
+      "GET",
+      BASE + "/repos/octo-org/octo-repo/contents/" + item.path + "?ref=main",
+      {status: item.status, body: json_stringify({message: item.message}), headers: item.headers},
+    )
+    const result = call("github.file.view", auth() + {repo: "octo-org/octo-repo", path: item.path, ref: "main"})
+    assert(is_err(result), item.path + " fails closed")
+    assert_eq(unwrap_err(result).code, item.code, item.path + " preserves error category")
+    assert_eq(unwrap_err(result).http_status, item.status, item.path + " preserves HTTP status")
+  }
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/contents/malformed-json?ref=main",
+    {status: 200, body: "{", headers: {"x-ratelimit-remaining": "10"}},
+  )
+  const bad_json = call("github.file.view", auth() + {repo: "octo-org/octo-repo", path: "malformed-json", ref: "main"})
+  assert(is_err(bad_json), "malformed JSON fails closed")
+  assert_eq(unwrap_err(bad_json).code, "invalid_response", "malformed JSON uses boundary error")
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/contents/malformed-shape?ref=main",
+    {status: 200, body: json_stringify({type: "dir"}), headers: {"x-ratelimit-remaining": "9"}},
+  )
+  const bad_shape = call(
+    "github.file.view",
+    auth() + {repo: "octo-org/octo-repo", path: "malformed-shape", ref: "main"},
+  )
+  assert(is_err(bad_shape), "malformed payload fails closed")
+  assert_eq(unwrap_err(bad_shape).code, "invalid_response", "shape error is normalized")
+}
+
+pipeline test_exact_workflow_run_and_jobs_are_normalized(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/actions/runs/321",
+    {
+      status: 200,
+      body: json_stringify(
+        {
+          id: 321,
+          workflow_id: 11,
+          run_number: 7,
+          run_attempt: 1,
+          name: "CI",
+          event: "workflow_dispatch",
+          status: "completed",
+          conclusion: "success",
+          head_branch: "main",
+          head_sha: "workflow-sha",
+          html_url: "https://github.com/octo-org/octo-repo/actions/runs/321",
+          created_at: "2026-07-13T12:00:00Z",
+          run_started_at: "2026-07-13T12:00:01Z",
+          updated_at: "2026-07-13T12:03:00Z",
+        },
+      ),
+      headers: {"x-ratelimit-remaining": "20"},
+    },
+  )
+  const run = call("github.actions.run", auth() + {repo: "octo-org/octo-repo", run_id: 321})
+  assert_eq(run.id, 321, "exact run id is retained")
+  assert_eq(run.conclusion, "success", "run conclusion is normalized")
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/actions/runs/321/jobs?filter=all",
+    {
+      status: 200,
+      body: json_stringify(
+        {
+          total_count: 1,
+          jobs: [
+            {
+              id: 901,
+              run_id: 321,
+              name: "test",
+              status: "completed",
+              conclusion: "success",
+              head_sha: "workflow-sha",
+              html_url: "https://github.com/octo-org/octo-repo/actions/runs/321/job/901",
+              runner_name: "GitHub Actions 1",
+              steps: [{number: 1, name: "Run tests", status: "completed", conclusion: "success"}],
+            },
+          ],
+        },
+      ),
+      headers: {"x-ratelimit-remaining": "19"},
+    },
+  )
+  const jobs = call("github.actions.run_jobs", auth() + {repo: "octo-org/octo-repo", run_id: 321, filter: "all"})
+  assert_eq(jobs.run_id, 321, "jobs bind to exact run")
+  assert_eq(jobs.jobs[0].steps[0].name, "Run tests", "step evidence is normalized")
+}
+
+pipeline test_workflow_dispatch_returns_exact_accepted_run_identity(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  http_mock(
+    "GET",
+    BASE
+      + "/repos/octo-org/octo-repo/actions/workflows/release.yml/runs?branch=main&event=workflow_dispatch&per_page=10",
+    {
+      status: 200,
+      body: json_stringify({total_count: 0, workflow_runs: []}),
+      headers: {"x-ratelimit-remaining": "20"},
+    },
+  )
+  http_mock(
+    "POST",
+    BASE + "/repos/octo-org/octo-repo/actions/workflows/release.yml/dispatches",
+    {
+      status: 200,
+      body: json_stringify({workflow_run_id: 322}),
+      headers: {"x-ratelimit-remaining": "19"},
+    },
+  )
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/actions/runs/322",
+    {
+      status: 200,
+      body: json_stringify(
+        {
+          id: 322,
+          workflow_id: 12,
+          event: "workflow_dispatch",
+          status: "queued",
+          conclusion: nil,
+          head_branch: "main",
+          head_sha: "dispatch-sha",
+          html_url: "https://github.com/octo-org/octo-repo/actions/runs/322",
+          created_at: "2026-07-13T12:10:00Z",
+          run_started_at: "2026-07-13T12:10:00Z",
+          updated_at: "2026-07-13T12:10:00Z",
+        },
+      ),
+      headers: {"x-ratelimit-remaining": "18"},
+    },
+  )
+  const dispatched = call(
+    "github.actions.workflow_dispatch",
+    auth()
+      + {repo: "octo-org/octo-repo", workflow_id: "release.yml", ref: "main", inputs: {version: "v1.2.3"}},
+  )
+  assert_eq(dispatched.accepted, true, "dispatch acceptance is explicit")
+  assert_eq(dispatched.run_id, 322, "dispatch is pinned to one run id")
+  assert_eq(dispatched.head_sha, "dispatch-sha", "dispatch returns observed source SHA")
+  assert_eq(len(http_mock_calls()), 3, "snapshot, dispatch, and exact run hydration are required")
+}

--- a/tests/orchestration_helpers.harn
+++ b/tests/orchestration_helpers.harn
@@ -474,13 +474,15 @@ pipeline test_ensure_auto_merge_already_enabled(task) {
       headers: {"x-ratelimit-remaining": "20"},
     },
   )
-  const result = github_ensure_auto_merge("octo-org", "octo-repo", 9, auth() + {method: "squash"})
-  assert_eq(result.ok, true, "ok=true")
+  const result = github_ensure_auto_merge(
+    "octo-org",
+    "octo-repo",
+    9,
+    auth() + {method: "squash", expected_head_oid: "abc"},
+  )
   assert_eq(result.state, "already_enabled", "already_enabled state")
   assert_eq(result.already_enabled, true, "already_enabled flag")
-  assert_eq(result.requested_method, "SQUASH", "requested method normalized")
   assert_eq(result.merge_method, "SQUASH", "merge method recorded from existing auto_merge")
-  assert_eq(result.strategy, "graphql_auto_merge", "strategy")
   http_mock_clear()
 }
 
@@ -527,11 +529,10 @@ pipeline test_ensure_auto_merge_enables_via_graphql(task) {
       headers: {"x-ratelimit-remaining": "18"},
     },
   )
-  const result = github_ensure_auto_merge("octo-org", "octo-repo", 12, auth())
-  assert_eq(result.ok, true, "ok=true")
+  const result = github_ensure_auto_merge("octo-org", "octo-repo", 12, auth() + {expected_head_oid: "fff"})
   assert_eq(result.state, "enabled", "state=enabled")
   assert_eq(result.already_enabled, false, "not already enabled")
-  assert_eq(result.requested_method, "MERGE", "default method MERGE")
+  assert_eq(result.merge_method, "MERGE", "default method MERGE")
   assert_eq(result.url, "https://github.com/octo-org/octo-repo/pull/12", "url surfaced")
   http_mock_clear()
 }
@@ -544,10 +545,9 @@ pipeline test_ensure_auto_merge_failed(task) {
     BASE + "/repos/octo-org/octo-repo/pulls/77",
     {status: 404, body: "{\"message\":\"Not Found\"}", headers: {"x-ratelimit-remaining": "10"}},
   )
-  const result = github_ensure_auto_merge("octo-org", "octo-repo", 77, auth())
-  assert_eq(result.ok, false, "ok=false")
-  assert_eq(result.state, "failed", "state=failed")
-  assert(result.error != nil, "error attached")
+  const result = github_ensure_auto_merge("octo-org", "octo-repo", 77, auth() + {expected_head_oid: "missing"})
+  assert(is_err(result), "provider error remains a Result failure")
+  assert_eq(unwrap_err(result).http_status, 404, "HTTP status remains structured")
   http_mock_clear()
 }
 

--- a/tests/pr_edit.harn
+++ b/tests/pr_edit.harn
@@ -52,6 +52,7 @@ pipeline default() {
   const edited = call(
     "github.pr.edit",
     auth
+      + {poll_interval_ms: 0}
       + {
       repo: "octo-org/octo-repo",
       number: 42,

--- a/tests/release_view.harn
+++ b/tests/release_view.harn
@@ -24,35 +24,24 @@ pipeline test_release_view_by_tag(task) {
     base + "/repos/octo-org/octo-repo/releases/tags/v1.2.3%2Bbuild%2F7",
     {status: 200, body: json_stringify(release_fixture(tag)), headers: {"x-ratelimit-remaining": "10"}},
   )
-  const release = github_release("octo-org", "octo-repo", tag, auth)
-  assert(release.ok, "release view succeeds")
-  assert_eq(release.repo, "octo-org/octo-repo", "repo is normalized")
-  assert_eq(release.tag_name, tag, "tag is preserved")
-  assert_eq(release.asset_names, ["harn.tar.gz"], "assets use the stable envelope")
+  const lookup = github_release("octo-org", "octo-repo", tag, auth)
+  assert(lookup.found, "release view succeeds")
+  assert_eq(lookup.repo, "octo-org/octo-repo", "repo is normalized")
+  assert_eq(lookup.release.tag_name, tag, "tag is preserved")
+  assert_eq(lookup.release.assets[0].name, "harn.tar.gz", "assets use the closed record")
   assert_eq(len(http_mock_calls()), 1, "exactly one request")
 }
 
-pipeline test_release_view_latest_and_invalid_tag(task) {
+pipeline test_release_view_requires_exact_tag(task) {
   egress_policy({allow: ["github-api.test"], default: "deny"})
   http_mock_clear()
   const base = "https://github-api.test"
   const auth = {api_base_url: base, installation_token: "token"}
-  http_mock(
-    "GET",
-    base + "/repos/octo-org/octo-repo/releases/latest",
-    {
-      status: 200,
-      body: json_stringify(release_fixture("v2.0.0")),
-      headers: {"x-ratelimit-remaining": "10"},
-    },
-  )
-  const latest = call("github.release.view", auth + {repo: "octo-org/octo-repo"})
-  assert(latest.ok, "nil tag delegates to latest")
-  assert_eq(latest.tag_name, "v2.0.0", "latest tag")
-  http_mock_clear()
+  const missing = call("github.release.view", auth + {repo: "octo-org/octo-repo"})
+  assert(is_err(missing), "missing exact tag fails closed")
   const invalid = github_release("octo-org", "octo-repo", "   ", auth)
-  assert_eq(invalid.ok, false, "blank tag fails closed")
-  assert_eq(invalid.error.code, "schema_drift", "blank tag error category")
+  assert(is_err(invalid), "blank tag fails closed")
+  assert_eq(unwrap_err(invalid).code, "schema_drift", "blank tag error category")
   assert_eq(len(http_mock_calls()), 0, "blank tag performs no request")
 }
 
@@ -70,11 +59,18 @@ pipeline test_release_view_provider_error(task) {
       headers: {"x-ratelimit-remaining": "10"},
     },
   )
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo",
+    {
+      status: 200,
+      body: json_stringify({full_name: "octo-org/octo-repo"}),
+      headers: {"x-ratelimit-remaining": "9"},
+    },
+  )
   const missing = github_release("octo-org", "octo-repo", "v9.9.9", auth)
-  assert_eq(missing.ok, false, "provider failure remains typed")
-  assert_eq(missing.repo, "octo-org/octo-repo", "error keeps repo identity")
-  assert(missing.error != nil, "provider error is retained")
-  assert_eq(missing.error.http_status, 404, "provider error retains structured HTTP status")
+  assert_eq(missing.found, false, "accessible repository proves release absence")
+  assert_eq(missing.state, "absent", "absence is explicit")
   http_mock(
     "GET",
     base + "/repos/octo-org/octo-repo/releases/tags/v9.9.8",
@@ -85,6 +81,6 @@ pipeline test_release_view_provider_error(task) {
     },
   )
   const forbidden = github_release("octo-org", "octo-repo", "v9.9.8", auth)
-  assert_eq(forbidden.ok, false, "permission failure remains typed")
-  assert_eq(forbidden.error.http_status, 403, "non-404 provider status is retained")
+  assert(is_err(forbidden), "permission failure remains typed")
+  assert_eq(unwrap_err(forbidden).http_status, 403, "non-404 provider status is retained")
 }

--- a/tests/repo_automation_methods.harn
+++ b/tests/repo_automation_methods.harn
@@ -221,9 +221,14 @@ pipeline test_repo_automation_methods(task) {
       headers: {"x-ratelimit-remaining": "5"},
     },
   )
-  const auto_merge = pulls_enable_auto_merge("octo-org", "octo-repo", 7, auth + {method: "squash"})
+  const auto_merge = pulls_enable_auto_merge(
+    "octo-org",
+    "octo-repo",
+    7,
+    auth + {method: "squash", expected_head_oid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+  )
   assert_eq(auto_merge.state, "enabled", "auto-merge enabled state")
-  assert_eq(auto_merge.requested_method, "SQUASH", "auto-merge merge method normalized")
+  assert_eq(auto_merge.merge_method, "SQUASH", "auto-merge merge method normalized")
   const calls = http_mock_calls()
   const dispatch_body = json_parse(calls[1].body)
   const mutation_body = json_parse(calls[10].body)

--- a/tests/typed_outbound.harn
+++ b/tests/typed_outbound.harn
@@ -65,7 +65,9 @@ pipeline default() {
   const prs = call("github.pr.list", auth + {repo: "octo-org/octo-repo", filters: {state: "open", per_page: 4}})
   assert_eq(prs[0].state, "green", "clean PR classified green")
   assert_eq(prs[1].state, "dirty", "dirty PR classified dirty")
-  assert_eq(prs[2].state, "queued", "queued PR classified queued")
+  assert_eq(prs[2].state, "green", "auto-merge arming is not queue evidence")
+  assert_eq(prs[2].auto_merge_armed, true, "auto-merge arming is retained separately")
+  assert_eq(prs[2].in_merge_queue, nil, "list does not invent queue membership")
   assert_eq(prs[3].state, "merged", "merged PR classified merged")
   assert_eq(prs[0].head.sha, "green-sha", "typed head sha")
   http_mock(
@@ -121,6 +123,84 @@ pipeline default() {
           status: 200,
           body: json_stringify({required_status_checks: {strict: true, contexts: ["Harn CI"]}}),
           headers: {"x-ratelimit-remaining": "18"},
+        },
+      ],
+    },
+  )
+  http_mock(
+    "POST",
+    base + "/graphql",
+    {
+      responses: [
+        {
+          status: 200,
+          body: json_stringify(
+            {data: {repository: {pullRequest: {number: 101, autoMergeRequest: nil, mergeQueueEntry: nil}}}},
+          ),
+          headers: {"x-ratelimit-remaining": "18"},
+        },
+        {
+          status: 200,
+          body: json_stringify(
+            {
+              data: {
+                repository: {
+                  mergeQueue: {
+                    url: "https://github.com/octo-org/octo-repo/queue/main",
+                    entries: {
+                      nodes: [
+                        {
+                          id: "MQE_103",
+                          position: 1,
+                          state: "AWAITING_CHECKS",
+                          enqueuedAt: "2026-05-02T12:04:00Z",
+                          jump: false,
+                          solo: false,
+                          estimatedTimeToMerge: 120,
+                          headCommit: {oid: "queued-sha"},
+                          pullRequest: {
+                            number: 103,
+                            url: "https://github.com/octo-org/octo-repo/pull/103",
+                            headRefOid: "queued-sha",
+                            baseRefName: "main",
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          ),
+          headers: {"x-ratelimit-remaining": "12"},
+        },
+        {
+          status: 200,
+          body: json_stringify(
+            {
+              data: {
+                enqueuePullRequest: {
+                  mergeQueueEntry: {
+                    id: "MQE_105",
+                    position: 2,
+                    state: "QUEUED",
+                    enqueuedAt: "2026-05-02T12:05:00Z",
+                    jump: false,
+                    solo: false,
+                    estimatedTimeToMerge: 180,
+                    headCommit: {oid: "enqueue-sha"},
+                    pullRequest: {
+                      number: 105,
+                      url: "https://github.com/octo-org/octo-repo/pull/105",
+                      headRefOid: "enqueue-sha",
+                      baseRefName: "main",
+                    },
+                  },
+                },
+              },
+            },
+          ),
+          headers: {"x-ratelimit-remaining": "11"},
         },
       ],
     },
@@ -208,37 +288,23 @@ pipeline default() {
   const logs = call("github.actions.logs", auth + {repo: "octo-org/octo-repo", check_id: 8001})
   assert_eq(logs.run_id, 6001, "check id resolves action run id")
   assert(logs.content.contains("succeeded"), "logs content returned")
-  http_mock(
-    "GET",
-    base + "/repos/octo-org/octo-repo/merge_queue/queues/main",
-    {
-      status: 200,
-      body: json_stringify(
-        {
-          base: "main",
-          entries: [{pull_request_number: 103, status: "queued", head_branch: "feature/queued"}],
-        },
-      ),
-      headers: {"x-ratelimit-remaining": "12"},
-    },
-  )
   const queue = call("github.merge_queue.entries", auth + {repo: "octo-org/octo-repo", branch: "main"})
   assert_eq(queue.entries[0].pull_number, 103, "merge queue entry PR number")
   http_mock(
-    "POST",
-    base + "/repos/octo-org/octo-repo/merge_queue/queues/main/items",
+    "GET",
+    base + "/repos/octo-org/octo-repo/pulls/105",
     {
-      status: 201,
-      body: json_stringify({pull_number: 105, status: "queued", priority: "normal"}),
+      status: 200,
+      body: json_stringify({number: 105, node_id: "PR_105", head: {sha: "enqueue-sha"}}),
       headers: {"x-ratelimit-remaining": "11"},
     },
   )
   const enqueued = call(
     "github.merge_queue.enqueue",
     auth
-      + {repo: "octo-org/octo-repo", branch: "main", pr_number: 105, method: "squash", priority: "normal"},
+      + {repo: "octo-org/octo-repo", pr_number: 105, expected_head_oid: "enqueue-sha"},
   )
-  assert_eq(enqueued.entry.status, "queued", "enqueue returns typed entry")
+  assert_eq(enqueued.entry.state, "queued", "enqueue returns typed entry")
   http_mock(
     "POST",
     base + "/repos/octo-org/octo-repo/issues",


### PR DESCRIPTION
## Summary

- add canonical closed `github.*` methods for PR create/list/files/comment, expected-head auto-merge, merge queue entries/membership, exact workflow dispatch/run/jobs, commit signatures, and exact file/release lookup
- preserve the base PR read when branch-protection administration enrichment is unavailable
- derive queue membership only from `mergeQueueEntry`, never `autoMergeRequest`
- prove exact lookup absence with a same-credential repository access read and otherwise fail closed

## Contract changes

- `github.pr.enable_auto_merge` and `github.merge_queue.enqueue` require `expected_head_oid`
- `github.release.view` requires an exact non-empty tag; latest release remains `github.release.latest`
- `github.file.view` requires an exact ref
- covered methods return closed normalized records or typed `Err` values, without raw/stdout compatibility envelopes

## Verification

- `harn --version` -> `harn 0.10.15`
- `harn connector test . --provider github --json` -> all 8 package stages pass
- `harn connector check . --provider github` -> 1 connector, 16 fixtures pass
- `scripts/check-release.sh v0.4.0` from detached commit `b9f1cac` -> check, lint, format, all tests, connector contract, and clean-consumer install/import pass
- live private dogfood: PR #1 create/list/edit/comment/files; stale head rejected; exact file/release absence proven; workflow run `29267135002`, job `86875356617`; invalid token returned `auth`/401; commit `d5e48b3` normalized as `unsigned`

Closes #171

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-github-connector/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786552827&installation_id=145974243&pr_number=172&repository=burin-labs%2Fharn-github-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-github-connector%2Fpull%2F172&signature=280fed9cd2a18253d78afd27c29c2006aa7ad410f070b36955b3137e319369ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->