### PR TITLE
Add typed release evidence contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,13 +83,16 @@ jobs:
       - name: Format
         run: harn fmt --check src tests
 
-      - name: Run smoke tests
+      - name: Run smoke pipelines
         shell: bash
         run: |
           set -euo pipefail
           for test in tests/*.harn; do
             harn run "${test}"
           done
+
+      - name: Run tests
+        run: harn test tests
 
       - name: Connector contract
         run: harn connector check .

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Call methods through `call(method, args)` unless a named helper fits better.
 
 | Area | Methods |
 |---|---|
-| Pull requests | `github.pr.list`, `github.pr.create`, `github.pr.view`, `github.pr.edit`, `github.pr.files`, `github.pr.checks`, `github.pr.merge`, `github.pr.enable_auto_merge`, `github.pr.comment`, `pulls.list`, `pulls.list_with_checks`, `pulls.get`, `pulls.update`, `pulls.create`, `pulls.merge`, `pulls.merge_safe`, `pulls.create_review_comment`, `pulls.get_diff`, `pulls.list_files`, `pulls.list_reviews`, `pull_requests.resolve_mergeable`, `repos.commit_pulls` |
+| Pull requests | `github.pr.list`, `github.pr.create`, `github.pr.view`, `github.pr.edit`, `github.pr.files`, `github.pr.commits`, `github.pr.checks`, `github.pr.merge`, `github.pr.enable_auto_merge`, `github.pr.comment`, `pulls.list`, `pulls.list_with_checks`, `pulls.get`, `pulls.update`, `pulls.create`, `pulls.merge`, `pulls.merge_safe`, `pulls.create_review_comment`, `pulls.get_diff`, `pulls.list_files`, `pulls.list_reviews`, `pull_requests.resolve_mergeable`, `repos.commit_pulls` |
 | Actions and checks | `github.actions.workflow_dispatch`, `github.actions.runs`, `github.actions.run`, `github.actions.run_jobs`, `github.actions.logs`, `actions.workflow_dispatch`, `actions.workflow_runs.list`, `actions.workflow_run.get`, `actions.workflow_run.jobs`, `check_runs.create`, `check_runs.update` |
 | Self-hosted runners | `actions.runners.registration_token`, `actions.runners.remove_token`, `actions.runners.generate_jitconfig`, `actions.runners.list`, `actions.runners.get`, `actions.runners.delete`, `actions.runners.downloads`, `actions.runners.labels.list`, `actions.runners.labels.add`, `actions.runners.labels.replace`, `actions.runners.labels.remove`, `actions.runner_groups.list`, `actions.runner_groups.create`, `actions.runner_groups.get`, `actions.runner_groups.update`, `actions.runner_groups.delete` |
 | User OAuth | `oauth.user.device_code`, `oauth.user.device_poll`, `oauth.user.exchange_code`, `oauth.user.refresh` |
@@ -154,9 +154,18 @@ raw REST responses for the same operation.
 - `github.pr.view` keeps the base PR read when branch-protection administration
   permission is unavailable. Its `branch_protection.available` is `false` and
   retains the structured permission error.
+- Canonical PR summaries, details, views, and lists expose `merged_at` and
+  `merge_commit_oid`. A PR reported as merged must carry both fields or the
+  response fails closed. `github.pr.commits` reads every commit page under one
+  stable head lease and returns each commit's message plus normalized signature
+  evidence; unsigned commits remain successful `verified: false` evidence. The
+  method fails closed rather than claim completeness when GitHub reports more
+  than the pull-request endpoint's 250-commit limit. Open-PR test-merge SHAs are
+  not exposed as actual merge commit OIDs.
 - `github.actions.workflow_dispatch` resolves one exact accepted run identity;
-  `github.actions.run` and `github.actions.run_jobs` return closed run, job, and
-  step evidence.
+  `github.actions.runs`, `github.actions.run`, and `github.actions.run_jobs`
+  return closed run, job, and step evidence. The run-list envelope uses typed
+  `runs`, never GitHub's raw `workflow_runs` payload.
 - `github.file.view` requires an exact `ref`, and `github.release.view` requires
   an exact `tag`. They return `state: "found" | "absent"`; a `404` is absence
   only after the same credential proves repository access. Masked private
@@ -177,6 +186,7 @@ Named helpers:
 | `pulls_update(owner, repo, number, edits, options)` | Update a closed set of editable PR fields. |
 | `pulls_merge_safe(owner, repo, number, options)` | Merge after checking branch protection. |
 | `pulls_enable_auto_merge(owner, repo, number, options)` | Enable GitHub auto-merge; `options.expected_head_oid` is required. |
+| `github_pr_commits(owner, repo, number, options)` | Read every commit and normalized signature under one stable PR head; `options.expected_head_oid` is optional. |
 | `actions_workflow_dispatch(owner, repo, workflow_id, ref, inputs, options)` | Dispatch a workflow. |
 | `actions_workflow_runs(owner, repo, options)` | List workflow runs. |
 | `actions_workflow_run(owner, repo, run_id, options)` | Fetch one workflow run by its exact id. |
@@ -335,6 +345,7 @@ harn connector check .
 for test in tests/*.harn; do
   harn run "$test" || exit 1
 done
+harn test tests
 ```
 
 `harn connector check .` runs the deterministic webhook fixtures declared in

--- a/changelog.d/305.added.md
+++ b/changelog.d/305.added.md
@@ -1,0 +1,1 @@
+Added stable typed pull-request commit pagination with per-commit signature evidence, canonical merged PR timestamp/OID fields, and a closed typed workflow-run list envelope for release automation. CI and release validation now execute the deterministic in-process named-test suite in addition to executable smoke pipelines.

--- a/scripts/check-release.sh
+++ b/scripts/check-release.sh
@@ -66,6 +66,7 @@ harn connector check . --provider github
 for test in tests/*.harn; do
   harn run "$test"
 done
+harn test tests
 
 smoke_root="$(mktemp -d)"
 trap 'rm -rf "$smoke_root"' EXIT

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -19,6 +19,7 @@ const GITHUB_OUTBOUND_METHODS = [
   "github.pr.view",
   "github.pr.edit",
   "github.pr.files",
+  "github.pr.commits",
   "github.pr.checks",
   "github.pr.merge",
   "github.pr.enable_auto_merge",
@@ -120,6 +121,8 @@ const GITHUB_CI_FAILURE_CONCLUSIONS = ["failure", "timed_out", "startup_failure"
 
 const GITHUB_CI_FAILURE_STATES = ["failure", "error"]
 
+const MAX_PULL_REQUEST_COMMIT_PAGES = 250
+
 type GithubCommitFileAddition = {path: string, contents_base64: string}
 
 type GithubCommitFileDeletion = {path: string}
@@ -159,6 +162,8 @@ type GithubPullRequestSummary = {
   github_state: string,
   draft: bool,
   merged: bool,
+  merged_at: string?,
+  merge_commit_oid: string?,
   mergeable: bool?,
   mergeable_state: string,
   base: GithubPullRequestRef,
@@ -203,6 +208,46 @@ type GithubCommitSignature = {
   signature_present: bool,
   payload_present: bool,
   verified_at: string?,
+}
+
+type GithubPullRequestCommit = {sha: string, message: string, signature: GithubCommitSignature}
+
+type GithubPullRequestCommits = {
+  repo: string,
+  pull_number: int,
+  head_ref: string,
+  head_sha: string,
+  total_count: int,
+  commits: list<GithubPullRequestCommit>,
+  pages_fetched: int,
+  per_page: int,
+}
+
+type GithubWorkflowRun = {
+  repo: string,
+  id: int,
+  workflow_id: int?,
+  run_number: int?,
+  run_attempt: int?,
+  name: string,
+  event: string,
+  status: string,
+  conclusion: string?,
+  head_branch: string,
+  head_sha: string,
+  url: string,
+  created_at: string?,
+  run_started_at: string?,
+  updated_at: string?,
+}
+
+type GithubWorkflowRuns = {
+  repo: string,
+  workflow_id: string?,
+  total_count: int,
+  runs: list<GithubWorkflowRun>,
+  page: int,
+  per_page: int,
 }
 
 type GithubConnectorState = {initialized: bool, active: bool, bindings: dict, ctx: dict}
@@ -405,6 +450,9 @@ pub fn call(method, args = {}) {
   }
   if method == "github.pr.files" {
     return __github_pr_files(args, cfg)
+  }
+  if method == "github.pr.commits" {
+    return __github_pr_commits(args, cfg)
   }
   if method == "github.pr.checks" {
     return __github_pr_checks(args, cfg)
@@ -756,6 +804,15 @@ pub fn pulls_merge_safe(owner, repo, number, options = nil) {
 pub fn pulls_enable_auto_merge(owner, repo, number, options = nil) {
   const opts = options ?? {}
   return call("github.pr.enable_auto_merge", opts + {owner: owner, repo: repo, pull_number: number})
+}
+
+/**
+ * Read every commit on one stable pull-request head, including normalized
+ * GitHub signature verification evidence for each commit.
+ */
+pub fn github_pr_commits(owner, repo, number, options = nil) {
+  const opts = options ?? {}
+  return call("github.pr.commits", opts + {owner: owner, repo: repo, pull_number: number})
 }
 
 /**
@@ -1844,7 +1901,7 @@ fn __github_pr_list(args, cfg) {
     if is_err(valid) {
       return valid
     }
-    if requested_state == "merged" && pull?.merged_at == nil && !(pull?.merged ?? false) {
+    if requested_state == "merged" && !__pull_is_merged(pull) {
       continue
     }
     typed = typed + [__typed_pr_summary(pull)]
@@ -2009,6 +2066,148 @@ fn __github_pr_files(args, cfg) {
   }
 }
 
+fn __github_pr_commits(args, cfg) {
+  const repo = __repo_parts(args)
+  if is_err(repo) {
+    return repo
+  }
+  const r = unwrap(repo)
+  const number = __positive_decimal(args?.pr_number ?? args?.number ?? args?.pull_number, nil)
+  if number == nil {
+    return __err("schema_drift", "github.pr.commits requires a positive pull-request number")
+  }
+  const per_page = if args?.per_page == nil {
+    100
+  } else {
+    __positive_decimal(args.per_page, 100)
+  }
+  if per_page == nil {
+    return __err("schema_drift", "github.pr.commits per_page must be an integer from 1 to 100")
+  }
+  const initial = __github_pull_identity(r, number, cfg, "github.pr.commits")
+  if is_err(initial) {
+    return initial
+  }
+  const initial_pull = unwrap(initial)
+  const head_sha = to_string(initial_pull.head.sha)
+  const expected_commit_count = __nonnegative_decimal(initial_pull?.commits)
+  if expected_commit_count == nil || expected_commit_count == 0 {
+    return __err("invalid_response", "github.pr.commits response omitted a positive commit count")
+  }
+  if expected_commit_count > 250 {
+    return __err(
+      "invalid_response",
+      "github.pr.commits cannot prove completeness above GitHub's 250-commit pull-request limit",
+    )
+  }
+  const expected_head_oid = trim(to_string(args?.expected_head_oid ?? ""))
+  if expected_head_oid != "" && expected_head_oid != head_sha {
+    return __stale_pr_head(expected_head_oid, head_sha)
+  }
+  const pages = __github_pr_commit_pages(r, number, expected_commit_count, per_page, cfg)
+  if is_err(pages) {
+    return pages
+  }
+  const page_result = unwrap(pages)
+  const commits: list<GithubPullRequestCommit> = page_result.commits
+  const terminal_commit = commits[len(commits) - 1]
+  if terminal_commit == nil {
+    return __err("invalid_response", "github.pr.commits could not resolve the terminal commit")
+  }
+  const terminal_sha = terminal_commit.sha
+  if terminal_sha != head_sha {
+    return __stale_pr_head(head_sha, terminal_sha)
+  }
+  const final = __github_pull_identity(r, number, cfg, "github.pr.commits")
+  if is_err(final) {
+    return final
+  }
+  const observed_head_oid = to_string(unwrap(final).head.sha)
+  if observed_head_oid != head_sha {
+    return __stale_pr_head(head_sha, observed_head_oid)
+  }
+  const observed_commit_count = __nonnegative_decimal(unwrap(final)?.commits)
+  if observed_commit_count != expected_commit_count {
+    return __err(
+      "stale_head",
+      "pull request commit count changed while reading canonical evidence",
+      {
+        expected_head_oid: head_sha,
+        observed_head_oid: observed_head_oid,
+        expected_commit_count: expected_commit_count,
+        observed_commit_count: observed_commit_count,
+      },
+    )
+  }
+  const result: GithubPullRequestCommits = {
+    repo: r.full_name,
+    pull_number: number,
+    head_ref: to_string(initial_pull.head.ref),
+    head_sha: head_sha,
+    total_count: expected_commit_count,
+    commits: commits,
+    pages_fetched: page_result.pages_fetched,
+    per_page: per_page,
+  }
+  return result
+}
+
+fn __github_pr_commit_pages(repo, number, expected_commit_count, per_page, cfg) {
+  let commits: list<GithubPullRequestCommit> = []
+  let seen_shas = {}
+  let page = 1
+  while page <= MAX_PULL_REQUEST_COMMIT_PAGES {
+    const raw_page = __github_json(
+      "GET",
+      __github_api_url(
+        cfg.api_base_url,
+        "/repos/" + repo.owner + "/" + repo.name + "/pulls/" + to_string(number)
+          + "/commits?per_page="
+          + to_string(per_page)
+          + "&page="
+          + to_string(page),
+      ),
+      nil,
+      cfg,
+    )
+    if is_err(raw_page) {
+      return raw_page
+    }
+    if type_of(raw_page) != "list" {
+      return __err("invalid_response", "github.pr.commits expected GitHub to return a commit list")
+    }
+    for raw_commit in raw_page {
+      const typed = __typed_pull_request_commit(repo.full_name, raw_commit)
+      if is_err(typed) {
+        return typed
+      }
+      const commit = unwrap(typed)
+      if seen_shas.get(commit.sha) {
+        return __err("invalid_response", "github.pr.commits returned a duplicate commit across pages")
+      }
+      seen_shas[commit.sha] = true
+      commits = commits + [commit]
+    }
+    if len(commits) == expected_commit_count {
+      break
+    }
+    if len(commits) > expected_commit_count || len(raw_page) < per_page {
+      return __err(
+        "invalid_response",
+        "github.pr.commits pagination did not match the pull-request commit count",
+      )
+    }
+    if page == MAX_PULL_REQUEST_COMMIT_PAGES {
+      return __err("invalid_response", "github.pr.commits exceeded the bounded pagination limit")
+    }
+    page = page + 1
+  }
+  if len(commits) == 0 {
+    return __err("invalid_response", "github.pr.commits returned no commits for the pull request")
+  }
+  return Ok({commits: commits, pages_fetched: page})
+}
+
 fn __github_pr_comment(args, cfg) {
   const commented = __github_issue_comment(
     args + {issue_number: args?.pr_number ?? args?.number ?? args?.pull_number},
@@ -2150,7 +2349,56 @@ fn __github_actions_runs(args, cfg) {
     return repo
   }
   const r = unwrap(repo)
-  return __actions_workflow_runs_list(args + {owner: r.owner, repo: r.name}, cfg)
+  const per_page = if args?.per_page == nil {
+    30
+  } else {
+    __positive_decimal(args.per_page, 100)
+  }
+  const page = if args?.page == nil {
+    1
+  } else {
+    __positive_decimal(args.page, nil)
+  }
+  if per_page == nil {
+    return __err("schema_drift", "github.actions.runs per_page must be an integer from 1 to 100")
+  }
+  if page == nil {
+    return __err("schema_drift", "github.actions.runs page must be a positive integer")
+  }
+  const response = __actions_workflow_runs_list(args + {owner: r.owner, repo: r.name}, cfg)
+  if is_err(response) {
+    return response
+  }
+  if type_of(response) != "dict" || response?.total_count == nil
+    || type_of(response?.workflow_runs) != "list" {
+    return __err("invalid_response", "github.actions.runs expected total_count and workflow_runs")
+  }
+  const total_count = __nonnegative_decimal(response.total_count)
+  if total_count == nil {
+    return __err("invalid_response", "github.actions.runs expected a non-negative total_count")
+  }
+  let runs: list<GithubWorkflowRun> = []
+  for run in response.workflow_runs {
+    const typed = __typed_workflow_run(r.full_name, run)
+    if is_err(typed) {
+      return typed
+    }
+    runs = runs + [unwrap(typed)]
+  }
+  const workflow_id = args?.workflow_id ?? args?.workflow ?? args?.workflow_file
+  const result: GithubWorkflowRuns = {
+    repo: r.full_name,
+    workflow_id: if workflow_id == nil {
+      nil
+    } else {
+      to_string(workflow_id)
+    },
+    total_count: total_count,
+    runs: runs,
+    page: page,
+    per_page: per_page,
+  }
+  return result
 }
 
 fn __github_actions_run(args, cfg) {
@@ -2163,7 +2411,11 @@ fn __github_actions_run(args, cfg) {
   if is_err(run) {
     return run
   }
-  return __typed_workflow_run(r.full_name, run)
+  const typed = __typed_workflow_run(r.full_name, run)
+  if is_err(typed) {
+    return typed
+  }
+  return unwrap(typed)
 }
 
 fn __github_actions_run_jobs(args, cfg) {
@@ -2371,13 +2623,23 @@ fn __github_commit_signature(args, cfg) {
   if is_err(commit) {
     return commit
   }
+  const typed = __typed_commit_signature(r.full_name, commit, "github.commit.signature")
+  if is_err(typed) {
+    return typed
+  }
+  return unwrap(typed)
+}
+
+fn __typed_commit_signature(repo, commit, surface) {
   const verification = commit?.commit?.verification
-  if commit?.sha == nil || type_of(verification) != "dict" || type_of(verification?.verified) != "bool"
+  if type_of(commit) != "dict" || trim(to_string(commit?.sha ?? "")) == ""
+    || type_of(verification) != "dict"
+    || type_of(verification?.verified) != "bool"
     || trim(to_string(verification?.reason ?? "")) == "" {
-    return __err("invalid_response", "github.commit.signature response omitted verification evidence")
+    return __err("invalid_response", surface + " response omitted verification evidence")
   }
   const result: GithubCommitSignature = {
-    repo: r.full_name,
+    repo: repo,
     sha: to_string(commit.sha),
     verified: verification.verified,
     reason: lowercase(to_string(verification.reason)),
@@ -2385,7 +2647,24 @@ fn __github_commit_signature(args, cfg) {
     payload_present: verification?.payload != nil && trim(to_string(verification.payload)) != "",
     verified_at: verification?.verified_at,
   }
-  return result
+  return Ok(result)
+}
+
+fn __typed_pull_request_commit(repo, commit) {
+  if type_of(commit) != "dict" || trim(to_string(commit?.sha ?? "")) == ""
+    || commit?.commit?.message == nil {
+    return __err("invalid_response", "github.pr.commits response omitted commit sha or message")
+  }
+  const signature = __typed_commit_signature(repo, commit, "github.pr.commits")
+  if is_err(signature) {
+    return signature
+  }
+  const result: GithubPullRequestCommit = {
+    sha: to_string(commit.sha),
+    message: to_string(commit.commit.message),
+    signature: unwrap(signature),
+  }
+  return Ok(result)
 }
 
 fn __github_release_assets(args, cfg) {
@@ -3087,6 +3366,14 @@ fn __positive_decimal(value, max_value) {
     return nil
   }
   return parsed
+}
+
+fn __nonnegative_decimal(value) {
+  const raw = trim(to_string(value ?? ""))
+  if len(regex_captures("^[0-9]+$", raw)) == 0 {
+    return nil
+  }
+  return to_int(raw)
 }
 
 /**
@@ -3905,7 +4192,13 @@ fn __typed_pr_summary(pull) {
     state: state,
     github_state: pull?.state ?? "",
     draft: pull?.draft ?? false,
-    merged: pull?.merged ?? false,
+    merged: __pull_is_merged(pull),
+    merged_at: if pull?.merged_at == nil {
+      nil
+    } else {
+      to_string(pull.merged_at)
+    },
+    merge_commit_oid: __pull_merge_commit_oid(pull),
     mergeable: pull?.mergeable,
     mergeable_state: pull?.mergeable_state ?? "unknown",
     base: __typed_ref(pull?.base),
@@ -3925,7 +4218,6 @@ fn __typed_pr_details(pull) {
     created_at: pull?.created_at,
     updated_at: pull?.updated_at,
     closed_at: pull?.closed_at,
-    merged_at: pull?.merged_at,
   }
 }
 
@@ -3977,7 +4269,61 @@ fn __validate_pull_response(pull, surface) {
     || trim(to_string(pull?.head?.sha ?? "")) == "" {
     return __err("invalid_response", surface + " response omitted required pull-request fields")
   }
+  const merge_commit_oid = __pull_merge_commit_oid(pull)
+  if __pull_is_merged(pull)
+    && (type_of(pull?.merged_at) != "string"
+    || trim(pull.merged_at) == ""
+    || merge_commit_oid == nil
+    || len(regex_captures("^[0-9a-fA-F]{40}$", merge_commit_oid)) == 0) {
+    return __err("invalid_response", surface + " response omitted required merged pull-request evidence")
+  }
   return Ok(true)
+}
+
+fn __pull_is_merged(pull) {
+  return (pull?.merged ?? false) || pull?.merged_at != nil
+}
+
+fn __pull_merge_commit_oid(pull) {
+  if !__pull_is_merged(pull) {
+    return nil
+  }
+  const oid = pull?.merge_commit_oid ?? pull?.merge_commit_sha
+  if oid == nil || trim(to_string(oid)) == "" {
+    return nil
+  }
+  return lowercase(to_string(oid))
+}
+
+fn __github_pull_identity(repo, number, cfg, surface) {
+  const pull = __github_json(
+    "GET",
+    __github_api_url(
+      cfg.api_base_url,
+      "/repos/" + repo.owner + "/" + repo.name + "/pulls/" + to_string(number),
+    ),
+    nil,
+    cfg,
+  )
+  if is_err(pull) {
+    return pull
+  }
+  const valid = __validate_pull_response(pull, surface)
+  if is_err(valid) {
+    return valid
+  }
+  if to_int(pull.number) != number {
+    return __err("invalid_response", surface + " response did not match the requested pull request")
+  }
+  return Ok(pull)
+}
+
+fn __stale_pr_head(expected_head_oid, observed_head_oid) {
+  return __err(
+    "stale_head",
+    "pull request head changed while reading canonical evidence",
+    {expected_head_oid: expected_head_oid, observed_head_oid: observed_head_oid},
+  )
 }
 
 fn __validate_pull_identity(pull, surface) {
@@ -4097,17 +4443,30 @@ fn __typed_workflow_dispatch(repo, ref, resolved) {
 }
 
 fn __typed_workflow_run(repo, run) {
-  if type_of(run) != "dict" || run?.id == nil || trim(to_string(run?.status ?? "")) == ""
+  const id = __actions_run_id(run?.id)
+  if type_of(run) != "dict" || id == nil || trim(to_string(run?.status ?? "")) == ""
     || trim(to_string(run?.event ?? "")) == ""
     || trim(to_string(run?.head_sha ?? "")) == "" {
     return __err("invalid_response", "github.actions.run response omitted exact run evidence")
   }
-  return {
+  const typed: GithubWorkflowRun = {
     repo: repo,
-    id: to_int(run.id),
-    workflow_id: run?.workflow_id,
-    run_number: run?.run_number,
-    run_attempt: run?.run_attempt,
+    id: id,
+    workflow_id: if run?.workflow_id == nil {
+      nil
+    } else {
+      to_int(run.workflow_id)
+    },
+    run_number: if run?.run_number == nil {
+      nil
+    } else {
+      to_int(run.run_number)
+    },
+    run_attempt: if run?.run_attempt == nil {
+      nil
+    } else {
+      to_int(run.run_attempt)
+    },
     name: to_string(run?.name ?? ""),
     event: to_string(run.event),
     status: lowercase(to_string(run.status)),
@@ -4119,10 +4478,23 @@ fn __typed_workflow_run(repo, run) {
     head_branch: to_string(run?.head_branch ?? ""),
     head_sha: to_string(run.head_sha),
     url: to_string(run?.html_url ?? run?.url ?? ""),
-    created_at: run?.created_at,
-    run_started_at: run?.run_started_at,
-    updated_at: run?.updated_at,
+    created_at: if run?.created_at == nil {
+      nil
+    } else {
+      to_string(run.created_at)
+    },
+    run_started_at: if run?.run_started_at == nil {
+      nil
+    } else {
+      to_string(run.run_started_at)
+    },
+    updated_at: if run?.updated_at == nil {
+      nil
+    } else {
+      to_string(run.updated_at)
+    },
   }
+  return Ok(typed)
 }
 
 fn __typed_workflow_job(job) {
@@ -4309,10 +4681,7 @@ fn __check_rollup(checks) {
 }
 
 fn __classify_pr_state(pull, rollup, queue) {
-  if pull?.merged ?? false {
-    return "merged"
-  }
-  if pull?.state == "closed" && pull?.merged_at != nil {
+  if __pull_is_merged(pull) {
     return "merged"
   }
   if queue != nil {

--- a/tests/hbf_contract_gaps.harn
+++ b/tests/hbf_contract_gaps.harn
@@ -1,0 +1,362 @@
+import { call, github_pr_commits } from "../src/lib"
+
+const BASE = "https://github-api.test"
+
+fn auth() {
+  return {api_base_url: BASE, installation_token: "test-token"}
+}
+
+fn pull(number, head_sha, merged = false, commit_count = 1) {
+  return {
+    number: number,
+    title: "PR " + to_string(number),
+    state: if merged {
+      "closed"
+    } else {
+      "open"
+    },
+    merged: merged,
+    merged_at: if merged {
+      "2026-07-13T12:00:00Z"
+    } else {
+      nil
+    },
+    merge_commit_sha: if merged {
+      "dddddddddddddddddddddddddddddddddddddddd"
+    } else {
+      nil
+    },
+    html_url: "https://github.com/octo-org/octo-repo/pull/" + to_string(number),
+    base: {ref: "main", sha: "base-sha", repo: {full_name: "octo-org/octo-repo"}},
+    head: {ref: "feature/" + to_string(number), sha: head_sha, repo: {full_name: "octo-org/octo-repo"}},
+    labels: [],
+    commits: commit_count,
+  }
+}
+
+fn commit(sha, message, verified, reason) {
+  return {
+    sha: sha,
+    commit: {
+      message: message,
+      verification: {
+        verified: verified,
+        reason: reason,
+        signature: if verified {
+          "signature"
+        } else {
+          nil
+        },
+        payload: if verified {
+          "payload"
+        } else {
+          nil
+        },
+        verified_at: if verified {
+          "2026-07-13T12:00:00Z"
+        } else {
+          nil
+        },
+      },
+    },
+  }
+}
+
+fn workflow_run(id, head_sha) {
+  return {
+    id: id,
+    workflow_id: 17,
+    run_number: 9,
+    run_attempt: 1,
+    name: "CI",
+    event: "merge_group",
+    status: "completed",
+    conclusion: "success",
+    head_branch: "gh-readonly-queue/main/pr-42",
+    head_sha: head_sha,
+    html_url: "https://github.com/octo-org/octo-repo/actions/runs/" + to_string(id),
+    created_at: "2026-07-13T12:00:00Z",
+    run_started_at: "2026-07-13T12:00:01Z",
+    updated_at: "2026-07-13T12:02:00Z",
+  }
+}
+
+pipeline test_pr_commits_reads_every_page_on_one_stable_head(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const head_sha = "cccccccccccccccccccccccccccccccccccccccc"
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/pulls/42",
+    {
+      responses: [
+        {
+          status: 200,
+          body: json_stringify(pull(42, head_sha, false, 3)),
+          headers: {"x-ratelimit-remaining": "20"},
+        },
+        {
+          status: 200,
+          body: json_stringify(pull(42, head_sha, false, 3)),
+          headers: {"x-ratelimit-remaining": "17"},
+        },
+      ],
+    },
+  )
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/pulls/42/commits?per_page=2&page=1",
+    {
+      status: 200,
+      body: json_stringify(
+        [
+          commit("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "first", true, "valid"),
+          commit("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "second", false, "unsigned"),
+        ],
+      ),
+      headers: {"x-ratelimit-remaining": "19"},
+    },
+  )
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/pulls/42/commits?per_page=2&page=2",
+    {
+      status: 200,
+      body: json_stringify([commit(head_sha, "third", true, "valid")]),
+      headers: {"x-ratelimit-remaining": "18"},
+    },
+  )
+  const result = github_pr_commits("octo-org", "octo-repo", 42, auth() + {per_page: 2, expected_head_oid: head_sha})
+  assert_eq(result.pull_number, 42, "receipt is bound to the exact pull request")
+  assert_eq(result.head_sha, head_sha, "receipt is bound to the stable head")
+  assert_eq(result.total_count, 3, "all pages are combined")
+  assert_eq(result.pages_fetched, 2, "pagination evidence is explicit")
+  assert_eq(result.commits[1].message, "second", "commit message is retained")
+  assert_eq(result.commits[1].signature.verified, false, "unsigned commit is typed evidence")
+  assert_eq(result.commits[1].signature.reason, "unsigned", "unsigned reason is retained")
+  assert_eq(result.commits[2].sha, head_sha, "terminal commit proves the observed head")
+  assert_eq(len(http_mock_calls()), 4, "head is checked before and after paginated reads")
+}
+
+pipeline test_pr_commits_rejects_malformed_signature_and_head_races(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const head_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/pulls/43",
+    {status: 200, body: json_stringify(pull(43, head_sha)), headers: {"x-ratelimit-remaining": "20"}},
+  )
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/pulls/43/commits?per_page=100&page=1",
+    {
+      status: 200,
+      body: json_stringify([{sha: head_sha, commit: {message: "malformed", verification: {verified: false}}}]),
+      headers: {"x-ratelimit-remaining": "19"},
+    },
+  )
+  const malformed = call("github.pr.commits", auth() + {repo: "octo-org/octo-repo", number: 43})
+  assert(is_err(malformed), "malformed signature evidence fails closed")
+  assert_eq(unwrap_err(malformed).code, "invalid_response", "boundary owns signature validation")
+  http_mock_clear()
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/pulls/430",
+    {
+      status: 200,
+      body: json_stringify(pull(430, head_sha, false, 251)),
+      headers: {"x-ratelimit-remaining": "20"},
+    },
+  )
+  const capped = call("github.pr.commits", auth() + {repo: "octo-org/octo-repo", number: 430})
+  assert(is_err(capped), "provider cap cannot masquerade as a complete commit list")
+  assert_eq(unwrap_err(capped).code, "invalid_response", "provider completeness limit fails closed")
+  assert_eq(len(http_mock_calls()), 1, "known-incomplete reads stop before commit pagination")
+  http_mock_clear()
+  const old_head = "cccccccccccccccccccccccccccccccccccccccc"
+  const new_head = "dddddddddddddddddddddddddddddddddddddddd"
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/pulls/44",
+    {
+      responses: [
+        {status: 200, body: json_stringify(pull(44, old_head)), headers: {"x-ratelimit-remaining": "20"}},
+        {status: 200, body: json_stringify(pull(44, new_head)), headers: {"x-ratelimit-remaining": "18"}},
+      ],
+    },
+  )
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/pulls/44/commits?per_page=100&page=1",
+    {
+      status: 200,
+      body: json_stringify([commit(old_head, "old head", true, "valid")]),
+      headers: {"x-ratelimit-remaining": "19"},
+    },
+  )
+  const raced = call("github.pr.commits", auth() + {repo: "octo-org/octo-repo", number: 44})
+  assert(is_err(raced), "head change during pagination fails closed")
+  assert_eq(unwrap_err(raced).code, "stale_head", "head race uses the canonical conflict code")
+  assert_eq(unwrap_err(raced).expected_head_oid, old_head, "initial head is retained")
+  assert_eq(unwrap_err(raced).observed_head_oid, new_head, "final head is reported")
+}
+
+pipeline test_merged_pr_evidence_is_normalized_and_required(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const merged = pull(45, "head-45", true)
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/pulls?state=closed",
+    {status: 200, body: json_stringify([merged]), headers: {"x-ratelimit-remaining": "20"}},
+  )
+  const listed = call("github.pr.list", auth() + {repo: "octo-org/octo-repo", filters: {state: "merged"}})
+  assert_eq(listed[0].merged_at, "2026-07-13T12:00:00Z", "list exposes merge time")
+  assert_eq(
+    listed[0].merge_commit_oid,
+    "dddddddddddddddddddddddddddddddddddddddd",
+    "list normalizes REST merge SHA",
+  )
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/pulls/45",
+    {status: 200, body: json_stringify(merged), headers: {"x-ratelimit-remaining": "19"}},
+  )
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/branches/main/protection",
+    {
+      status: 404,
+      body: json_stringify({message: "Not Found"}),
+      headers: {"x-ratelimit-remaining": "18"},
+    },
+  )
+  http_mock(
+    "POST",
+    BASE + "/graphql",
+    {
+      status: 200,
+      body: json_stringify(
+        {data: {repository: {pullRequest: {number: 45, autoMergeRequest: nil, mergeQueueEntry: nil}}}},
+      ),
+      headers: {"x-ratelimit-remaining": "17"},
+    },
+  )
+  const viewed = call("github.pr.view", auth() + {repo: "octo-org/octo-repo", number: 45})
+  assert_eq(viewed.merge_commit_oid, listed[0].merge_commit_oid, "view and list share one normalizer")
+  http_mock_clear()
+  const missing_oid = pull(46, "head-46", true) + {merge_commit_sha: nil}
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/pulls?state=closed",
+    {status: 200, body: json_stringify([missing_oid]), headers: {"x-ratelimit-remaining": "20"}},
+  )
+  const malformed = call("github.pr.list", auth() + {repo: "octo-org/octo-repo", filters: {state: "merged"}})
+  assert(is_err(malformed), "merged PR without an OID fails closed")
+  assert_eq(
+    unwrap_err(malformed).code,
+    "invalid_response",
+    "merged evidence is required at the boundary",
+  )
+  http_mock_clear()
+  const open = pull(47, "head-47") + {merge_commit_sha: "synthetic-test-merge"}
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/pulls?state=open",
+    {status: 200, body: json_stringify([open]), headers: {"x-ratelimit-remaining": "20"}},
+  )
+  const open_list = call("github.pr.list", auth() + {repo: "octo-org/octo-repo", filters: {state: "open"}})
+  assert_eq(
+    open_list[0].merge_commit_oid,
+    nil,
+    "open PR test-merge SHA is not published as merge evidence",
+  )
+}
+
+pipeline test_actions_runs_returns_closed_typed_envelope(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const url = BASE
+    + "/repos/octo-org/octo-repo/actions/workflows/ci.yml/runs?branch=main&event=merge_group&per_page=25&page=2"
+  http_mock(
+    "GET",
+    url,
+    {
+      responses: [
+        {
+          status: 200,
+          body: json_stringify(
+            {total_count: 1, workflow_runs: [workflow_run(701, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]},
+          ),
+          headers: {"x-ratelimit-remaining": "20"},
+        },
+        {
+          status: 200,
+          body: json_stringify({total_count: 1, workflow_runs: [{id: 702, status: "completed"}]}),
+          headers: {"x-ratelimit-remaining": "19"},
+        },
+      ],
+    },
+  )
+  const result = call(
+    "github.actions.runs",
+    auth()
+      + {
+      repo: "octo-org/octo-repo",
+      workflow_id: "ci.yml",
+      branch: "main",
+      event: "merge_group",
+      per_page: 25,
+      page: 2,
+    },
+  )
+  assert_eq(result.repo, "octo-org/octo-repo", "run list is repository-bound")
+  assert_eq(result.workflow_id, "ci.yml", "workflow filter is retained")
+  assert_eq(result.page, 2, "page evidence is explicit")
+  assert_eq(result.runs[0].id, 701, "raw workflow_runs is projected to typed runs")
+  assert_eq(result.runs[0].event, "merge_group", "run event is required and normalized")
+  assert_eq(result.runs[0].head_sha, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "run head is exact")
+  assert(result.get("workflow_runs") == nil, "raw GitHub envelope is not exposed")
+  const malformed = call(
+    "github.actions.runs",
+    auth()
+      + {
+      repo: "octo-org/octo-repo",
+      workflow_id: "ci.yml",
+      branch: "main",
+      event: "merge_group",
+      per_page: 25,
+      page: 2,
+    },
+  )
+  assert(is_err(malformed), "malformed run evidence fails closed")
+  assert_eq(unwrap_err(malformed).code, "invalid_response", "run shape is validated once")
+}
+
+pipeline test_canonical_contracts_distinguish_auth_and_network_failures(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/actions/runs",
+    {status: 401, body: json_stringify({message: "Bad credentials"}), headers: {}},
+  )
+  const unauthorized = call("github.actions.runs", auth() + {repo: "octo-org/octo-repo"})
+  assert(is_err(unauthorized), "authentication failure is not an empty run list")
+  assert_eq(unwrap_err(unauthorized).code, "auth", "authentication remains distinct")
+  assert_eq(unwrap_err(unauthorized).http_status, 401, "auth status is retained")
+  http_mock(
+    "GET",
+    BASE + "/repos/octo-org/octo-repo/pulls/47",
+    {status: 500, body: json_stringify({message: "server error"}), headers: {}},
+  )
+  const unavailable = call("github.pr.commits", auth() + {repo: "octo-org/octo-repo", number: 47})
+  assert(is_err(unavailable), "provider failure is not an empty commit list")
+  assert_eq(
+    unwrap_err(unavailable).code,
+    "network",
+    "provider failure remains network-class evidence",
+  )
+  assert_eq(unwrap_err(unavailable).http_status, 500, "provider status is retained")
+}

--- a/tests/pr_list_contract.harn
+++ b/tests/pr_list_contract.harn
@@ -10,6 +10,11 @@ fn pull_fixture(number, head, merged_at = nil) {
     title: "PR " + to_string(number),
     state: "closed",
     merged_at: merged_at,
+    merge_commit_sha: if merged_at == nil {
+      nil
+    } else {
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
     html_url: "https://github.com/octo-org/octo-repo/pull/" + to_string(number),
     base: {ref: "main", repo: {full_name: "octo-org/octo-repo"}},
     head: {ref: head, sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
@@ -87,6 +92,12 @@ pipeline test_pr_list_merged_maps_to_closed_and_filters_unmerged_prs(task) {
       + {repo: "octo-org/octo-repo", filters: {state: "merged", base: "main", per_page: 30}},
   )
   assert_eq(pulls.map({ pull -> pull.number }), [8], "only actually merged PRs survive")
+  assert_eq(pulls[0].merged_at, "2026-07-13T00:00:00Z", "merge timestamp is canonical evidence")
+  assert_eq(
+    pulls[0].merge_commit_oid,
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "REST merge SHA is normalized to merge_commit_oid",
+  )
   assert_eq(len(http_mock_calls()), 1, "merged state uses one closed-PR request")
 }
 

--- a/tests/typed_outbound.harn
+++ b/tests/typed_outbound.harn
@@ -54,6 +54,7 @@ pipeline default() {
             state: "closed",
             merged: true,
             merged_at: "2026-05-02T12:00:00Z",
+            merge_commit_sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
             base: {ref: "main", repo: {full_name: "octo-org/octo-repo"}},
             head: {ref: "feature/merged", sha: "merged-sha", repo: {full_name: "octo-org/octo-repo"}},
           },


### PR DESCRIPTION
## Summary
- add stable paginated `github.pr.commits` with per-commit signature evidence and head/count revalidation
- expose exact merged PR timestamp/OID evidence and closed typed Actions run lists
- fail closed on GitHub PR commit caps, malformed provider records, head races, and auth/transport failures
- run both executable smoke pipelines and named in-process tests in CI/release validation

## Verification
- Harn v0.10.15 `fmt --check`, `check`, `lint`, `git diff --check`
- focused executable contract files 3/3
- named tests 53/53 in 605ms
- connector fixtures 16/16
- live read-only Harn PR commit/signature and merge-group Actions dogfood

Prerequisite for burin-labs/harn-bump-fleet#305.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-github-connector/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786555579&installation_id=145974243&pr_number=173&repository=burin-labs%2Fharn-github-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-github-connector%2Fpull%2F173&signature=8a31d6f333a6b7d85082dbd9e3e72c6f93bf673aad4fdae3e0a2ef961b346055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->