### PR TITLE
github: add leased release body edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Call methods through `call(method, args)` unless a named helper fits better.
 | Self-hosted runners | `actions.runners.registration_token`, `actions.runners.remove_token`, `actions.runners.generate_jitconfig`, `actions.runners.list`, `actions.runners.get`, `actions.runners.delete`, `actions.runners.downloads`, `actions.runners.labels.list`, `actions.runners.labels.add`, `actions.runners.labels.replace`, `actions.runners.labels.remove`, `actions.runner_groups.list`, `actions.runner_groups.create`, `actions.runner_groups.get`, `actions.runner_groups.update`, `actions.runner_groups.delete` |
 | User OAuth | `oauth.user.device_code`, `oauth.user.device_poll`, `oauth.user.exchange_code`, `oauth.user.refresh` |
 | Issues | `github.issue.create`, `github.issue.comment`, `issues.create_comment`, `issues.create`, `issues.create_with_template`, `issues.update`, `issues.add_labels` |
-| Repository and release data | `github.file.view`, `github.release.view`, `github.release.latest`, `github.release.assets`, `github.commit.signature`, `github.branch.protection`, `github.branch.create_signed_commit`, `repos.get_content`, `repos.get_text`, `repos.create_or_update_file`, `repos.put_content`, `repos.delete_file`, `repos.get_latest_release`, `repos.list_release_assets`, `repos.get_branch_protection`, `git.create_commit`, `git.delete_ref` |
+| Repository and release data | `github.file.view`, `github.release.view`, `github.release.edit_body`, `github.release.latest`, `github.release.assets`, `github.commit.signature`, `github.branch.protection`, `github.branch.create_signed_commit`, `repos.get_content`, `repos.get_text`, `repos.create_or_update_file`, `repos.put_content`, `repos.delete_file`, `repos.get_latest_release`, `repos.list_release_assets`, `repos.get_branch_protection`, `git.create_commit`, `git.delete_ref` |
 | Merge queue | `github.merge_queue.entries`, `github.merge_queue.membership`, `github.merge_queue.enqueue` |
 | Raw access | `api_call`, `graphql` |
 
@@ -169,7 +169,11 @@ raw REST responses for the same operation.
 - `github.file.view` requires an exact `ref`, and `github.release.view` requires
   an exact `tag`. They return `state: "found" | "absent"`; a `404` is absence
   only after the same credential proves repository access. Masked private
-  resources and transport failures remain `Err`.
+  resources and transport failures remain `Err`. Exact release views include
+  the release id, tag-ref object, and peeled tag target as a mutation lease.
+- `github.release.edit_body` accepts that complete lease and re-observes it
+  before issuing one body-only metadata update. Stale release ids or tag
+  identities fail closed; tags and assets cannot be included in the request.
 - `github.commit.signature` returns GitHub's normalized `verified`, `reason`,
   material-presence, and `verified_at` evidence. Unsigned and invalid
   signatures are successful reads with `verified: false`, not transport errors.
@@ -209,6 +213,7 @@ Named helpers:
 | `github_resolve_pr_for_sha(owner, repo, sha, options)` | Resolve the PR for a commit SHA, preferring payload `pull_requests[]` and falling back to `repos.commit_pulls`. |
 | `github_create_signed_commit(request, options)` | Atomically append file additions/deletions at an expected head OID through GitHub's verified App-signing path. |
 | `github_release(owner, repo, tag, options)` | Look up one exact release tag with proven-absence semantics. |
+| `github_release_edit_body(owner, repo, tag, body, lease, options)` | Replace an exact release body under its observed release and tag lease. |
 | `github_extract_mentions(body)` | Pure string parse of `@handle command args...` mentions in a body. |
 | `actions_runner_registration_token(scope, options)` | Create a self-hosted runner registration token (`scope` is `{org}` or `{owner, repo}`). |
 | `actions_runner_generate_jitconfig(scope, name, runner_group_id, labels, options)` | Generate a stateless single-use JIT runner config. |

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -30,6 +30,7 @@ const GITHUB_OUTBOUND_METHODS = [
   "github.actions.run_jobs",
   "github.actions.logs",
   "github.release.view",
+  "github.release.edit_body",
   "github.release.latest",
   "github.release.assets",
   "github.merge_queue.entries",
@@ -493,6 +494,9 @@ pub fn call(method, args = {}) {
   }
   if method == "github.release.view" {
     return __github_release_view(args, cfg)
+  }
+  if method == "github.release.edit_body" {
+    return __github_release_edit_body(args, cfg)
   }
   if method == "github.release.latest" {
     return __github_release_latest(args, cfg)
@@ -1016,6 +1020,24 @@ pub fn github_latest_release(owner, repo, options = nil) {
 pub fn github_release(owner, repo, tag, options = nil) {
   const opts = options ?? {}
   return call("github.release.view", opts + {owner: owner, repo: repo, tag: tag})
+}
+
+/** Replace an exact release body under its observed release and tag leases. */
+pub fn github_release_edit_body(owner, repo, tag, body, lease, options = nil) {
+  const opts = options ?? {}
+  return call(
+    "github.release.edit_body",
+    opts
+      + {
+      owner: owner,
+      repo: repo,
+      tag: tag,
+      body: body,
+      expected_release_id: lease?.release_id,
+      expected_tag_ref_oid: lease?.tag_ref_oid,
+      expected_tag_target_oid: lease?.tag_target_oid,
+    },
+  )
 }
 
 /**
@@ -2689,7 +2711,144 @@ fn __github_release_view(args, cfg) {
   if is_err(typed) {
     return typed
   }
-  return {repo: r.full_name, tag: tag, state: "found", found: true, release: unwrap(typed)}
+  const tag_lease = __github_tag_lease(r, tag, cfg)
+  if is_err(tag_lease) {
+    return tag_lease
+  }
+  return {
+    repo: r.full_name,
+    tag: tag,
+    state: "found",
+    found: true,
+    release: unwrap(typed),
+    lease: unwrap(tag_lease) + {release_id: unwrap(typed).id},
+  }
+}
+
+fn __github_release_edit_body(args, cfg) {
+  const repo = __repo_parts(args)
+  if is_err(repo) {
+    return repo
+  }
+  const r = unwrap(repo)
+  const tag = trim(to_string(args?.tag ?? ""))
+  const expected_release_id = args?.expected_release_id
+  const expected_tag_ref_oid = trim(to_string(args?.expected_tag_ref_oid ?? ""))
+  const expected_tag_target_oid = trim(to_string(args?.expected_tag_target_oid ?? ""))
+  if tag == "" || args?.body == nil || expected_release_id == nil
+    || expected_tag_ref_oid == ""
+    || expected_tag_target_oid == "" {
+    return __err(
+      "schema_drift",
+      "github.release.edit_body requires tag, body, and the complete observed release/tag lease",
+    )
+  }
+  const observed = __github_release_view(args + {owner: r.owner, repo: r.name, tag: tag}, cfg)
+  if is_err(observed) {
+    return observed
+  }
+  if !observed.found {
+    return __err("not_found", "release does not exist for the exact tag", {tag: tag})
+  }
+  const lease = observed.lease
+  if lease.release_id != expected_release_id {
+    return __err(
+      "stale_release",
+      "release identity changed before metadata edit",
+      {expected_release_id: expected_release_id, observed_release_id: lease.release_id},
+    )
+  }
+  if lease.tag_ref_oid != expected_tag_ref_oid
+    || lease.tag_target_oid != expected_tag_target_oid {
+    return __err(
+      "stale_tag",
+      "tag identity changed before release metadata edit",
+      {
+        expected_tag_ref_oid: expected_tag_ref_oid,
+        observed_tag_ref_oid: lease.tag_ref_oid,
+        expected_tag_target_oid: expected_tag_target_oid,
+        observed_tag_target_oid: lease.tag_target_oid,
+      },
+    )
+  }
+  const body = to_string(args.body)
+  const edited = __github_json(
+    "PATCH",
+    __github_api_url(
+      cfg.api_base_url,
+      "/repos/" + r.owner + "/" + r.name + "/releases/" + to_string(lease.release_id),
+    ),
+    {body: body},
+    cfg,
+  )
+  if is_err(edited) {
+    return edited
+  }
+  const typed = __typed_release(edited)
+  if is_err(typed) {
+    return typed
+  }
+  const release = unwrap(typed)
+  if release.id != lease.release_id || release.tag_name != tag || release.body != body {
+    return __err("invalid_response", "release metadata edit response did not confirm the mutation")
+  }
+  return {
+    repo: r.full_name,
+    tag: tag,
+    state: "edited",
+    release_id: release.id,
+    tag_ref_oid: lease.tag_ref_oid,
+    tag_target_oid: lease.tag_target_oid,
+    body: release.body,
+    url: release.url,
+  }
+}
+
+fn __github_tag_lease(repo, tag, cfg) {
+  const ref = __github_json(
+    "GET",
+    __github_api_url(
+      cfg.api_base_url,
+      "/repos/" + repo.owner + "/" + repo.name + "/git/ref/tags/" + url_encode(tag),
+    ),
+    nil,
+    cfg,
+  )
+  if is_err(ref) {
+    return ref
+  }
+  const ref_oid = trim(to_string(ref?.object?.sha ?? ""))
+  let target_oid = ref_oid
+  let target_type = lowercase(trim(to_string(ref?.object?.type ?? "")))
+  if trim(to_string(ref?.ref ?? "")) != "refs/tags/" + tag || ref_oid == ""
+    || target_type == "" {
+    return __err("invalid_response", "GitHub tag reference omitted exact identity")
+  }
+  let depth = 0
+  while target_type == "tag" && depth < 16 {
+    const object = __github_json(
+      "GET",
+      __github_api_url(
+        cfg.api_base_url,
+        "/repos/" + repo.owner + "/" + repo.name + "/git/tags/" + target_oid,
+      ),
+      nil,
+      cfg,
+    )
+    if is_err(object) {
+      return object
+    }
+    target_oid = trim(to_string(object?.object?.sha ?? ""))
+    target_type = lowercase(trim(to_string(object?.object?.type ?? "")))
+    if target_oid == "" || target_type == "" {
+      return __err("invalid_response", "GitHub annotated tag omitted its target identity")
+    }
+    depth = depth + 1
+  }
+  if target_type == "tag" {
+    return __err("invalid_response", "GitHub annotated tag chain exceeded the safety limit")
+  }
+  return Ok({tag_ref_oid: ref_oid, tag_target_oid: target_oid, tag_target_type: target_type})
 }
 
 fn __github_file_view(args, cfg) {
@@ -4648,6 +4807,7 @@ fn __typed_release(release) {
       prerelease: release?.prerelease ?? false,
       url: to_string(release?.html_url ?? release?.url ?? ""),
       target_commitish: to_string(release?.target_commitish ?? ""),
+      body: to_string(release?.body ?? ""),
       published_at: release?.published_at,
       assets: assets,
     },

--- a/tests/release_edit_body.harn
+++ b/tests/release_edit_body.harn
@@ -1,0 +1,200 @@
+import { github_release_edit_body } from "../src/lib"
+
+const REF_OID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+const TARGET_OID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+fn release_fixture(id, body) {
+  return {
+    id: id,
+    tag_name: "v1.2.3",
+    name: "v1.2.3",
+    body: body,
+    draft: false,
+    prerelease: false,
+    html_url: "https://github.com/octo-org/octo-repo/releases/tag/v1.2.3",
+    assets: [{id: 91, name: "artifact.tar.gz"}],
+  }
+}
+
+fn mock_release(base, id, body) {
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/releases/tags/v1.2.3",
+    {
+      status: 200,
+      body: json_stringify(release_fixture(id, body)),
+      headers: {"x-ratelimit-remaining": "10"},
+    },
+  )
+}
+
+fn mock_annotated_tag(base, ref_oid, target_oid) {
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/git/ref/tags/v1.2.3",
+    {
+      status: 200,
+      body: json_stringify({ref: "refs/tags/v1.2.3", object: {type: "tag", sha: ref_oid}}),
+      headers: {"x-ratelimit-remaining": "9"},
+    },
+  )
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/git/tags/" + ref_oid,
+    {
+      status: 200,
+      body: json_stringify({sha: ref_oid, object: {type: "commit", sha: target_oid}}),
+      headers: {"x-ratelimit-remaining": "8"},
+    },
+  )
+}
+
+fn lease(overrides = nil) {
+  return {release_id: 701, tag_ref_oid: REF_OID, tag_target_oid: TARGET_OID}
+    + (overrides ?? {})
+}
+
+fn auth(base) {
+  return {api_base_url: base, installation_token: "token"}
+}
+
+pipeline test_release_body_edit_is_leased_and_metadata_only(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://github-api.test"
+  const replacement = "Exact notes\n\nCorrection footer.\n"
+  mock_release(base, 701, "Old notes\n")
+  mock_annotated_tag(base, REF_OID, TARGET_OID)
+  http_mock(
+    "PATCH",
+    base + "/repos/octo-org/octo-repo/releases/701",
+    {
+      status: 200,
+      body: json_stringify(release_fixture(701, replacement)),
+      headers: {"x-ratelimit-remaining": "7"},
+    },
+  )
+  const receipt = github_release_edit_body(
+    "octo-org",
+    "octo-repo",
+    "v1.2.3",
+    replacement,
+    lease(),
+    auth(base),
+  )
+  assert_eq(receipt.state, "edited", "typed edit receipt")
+  assert_eq(receipt.release_id, 701, "release lease is retained")
+  assert_eq(receipt.tag_ref_oid, REF_OID, "tag object lease is retained")
+  assert_eq(receipt.tag_target_oid, TARGET_OID, "tag target lease is retained")
+  assert_eq(receipt.body, replacement, "resulting body is exact")
+  const calls = http_mock_calls()
+  assert_eq(len(calls), 4, "lease observations precede one mutation")
+  assert_eq(calls[3].method, "PATCH", "only final request mutates")
+  const patch_body = json_parse(calls[3].body)
+  assert_eq(len(patch_body), 1, "metadata edit sends one field")
+  assert_eq(patch_body.get("body"), replacement, "metadata edit sends exact body")
+  assert_eq(patch_body.get("tag_name"), nil, "metadata edit cannot retag")
+  assert_eq(patch_body.get("assets"), nil, "metadata edit cannot modify assets")
+}
+
+pipeline test_release_body_edit_rejects_stale_release(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://github-api.test"
+  mock_release(base, 702, "Old notes\n")
+  mock_annotated_tag(base, REF_OID, TARGET_OID)
+  const edited = github_release_edit_body(
+    "octo-org",
+    "octo-repo",
+    "v1.2.3",
+    "New notes\n",
+    lease(),
+    auth(base),
+  )
+  assert(is_err(edited), "stale release fails closed")
+  assert_eq(unwrap_err(edited).code, "stale_release", "stale release category")
+  assert_eq(len(http_mock_calls()), 3, "stale release performs no mutation")
+}
+
+pipeline test_release_body_edit_rejects_stale_tag(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://github-api.test"
+  mock_release(base, 701, "Old notes\n")
+  mock_annotated_tag(base, REF_OID, "cccccccccccccccccccccccccccccccccccccccc")
+  const edited = github_release_edit_body(
+    "octo-org",
+    "octo-repo",
+    "v1.2.3",
+    "New notes\n",
+    lease(),
+    auth(base),
+  )
+  assert(is_err(edited), "stale tag fails closed")
+  assert_eq(unwrap_err(edited).code, "stale_tag", "stale tag category")
+  assert_eq(len(http_mock_calls()), 3, "stale tag performs no mutation")
+}
+
+pipeline test_release_body_edit_rejects_missing_release(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://github-api.test"
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/releases/tags/v1.2.3",
+    {
+      status: 404,
+      body: json_stringify({message: "Not Found"}),
+      headers: {"x-ratelimit-remaining": "10"},
+    },
+  )
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo",
+    {
+      status: 200,
+      body: json_stringify({full_name: "octo-org/octo-repo"}),
+      headers: {"x-ratelimit-remaining": "9"},
+    },
+  )
+  const edited = github_release_edit_body(
+    "octo-org",
+    "octo-repo",
+    "v1.2.3",
+    "New notes\n",
+    lease(),
+    auth(base),
+  )
+  assert(is_err(edited), "missing release fails closed")
+  assert_eq(unwrap_err(edited).code, "not_found", "missing release category")
+  assert_eq(len(http_mock_calls()), 2, "missing release performs no mutation")
+}
+
+pipeline test_release_body_edit_normalizes_provider_failure(task) {
+  egress_policy({allow: ["github-api.test"], default: "deny"})
+  http_mock_clear()
+  const base = "https://github-api.test"
+  mock_release(base, 701, "Old notes\n")
+  mock_annotated_tag(base, REF_OID, TARGET_OID)
+  http_mock(
+    "PATCH",
+    base + "/repos/octo-org/octo-repo/releases/701",
+    {
+      status: 403,
+      body: json_stringify({message: "Resource not accessible by integration"}),
+      headers: {"x-ratelimit-remaining": "7"},
+    },
+  )
+  const edited = github_release_edit_body(
+    "octo-org",
+    "octo-repo",
+    "v1.2.3",
+    "New notes\n",
+    lease(),
+    auth(base),
+  )
+  assert(is_err(edited), "provider failure remains typed")
+  assert_eq(unwrap_err(edited).code, "missing_scopes", "provider failure category")
+  assert_eq(unwrap_err(edited).http_status, 403, "provider status is retained")
+}

--- a/tests/release_view.harn
+++ b/tests/release_view.harn
@@ -9,6 +9,7 @@ fn release_fixture(tag) {
     prerelease: true,
     html_url: "https://github.com/octo-org/octo-repo/releases/tag/" + tag,
     published_at: "2026-07-13T00:00:00Z",
+    body: "Notes for " + tag,
     assets: [{id: 11, name: "harn.tar.gz"}],
   }
 }
@@ -28,12 +29,32 @@ pipeline test_release_view_by_tag(task) {
       headers: {"x-ratelimit-remaining": "10"},
     },
   )
+  http_mock(
+    "GET",
+    base + "/repos/octo-org/octo-repo/git/ref/tags/v1.2.3%2Bbuild%2F7",
+    {
+      status: 200,
+      body: json_stringify(
+        {
+          ref: "refs/tags/" + tag,
+          object: {type: "commit", sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+        },
+      ),
+      headers: {"x-ratelimit-remaining": "9"},
+    },
+  )
   const lookup = github_release("octo-org", "octo-repo", tag, auth)
   assert(lookup.found, "release view succeeds")
   assert_eq(lookup.repo, "octo-org/octo-repo", "repo is normalized")
   assert_eq(lookup.release.tag_name, tag, "tag is preserved")
+  assert_eq(lookup.release.body, "Notes for " + tag, "body is preserved byte-for-byte")
+  assert_eq(
+    lookup.lease.tag_target_oid,
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "tag target is leased",
+  )
   assert_eq(lookup.release.assets[0].name, "harn.tar.gz", "assets use the closed record")
-  assert_eq(len(http_mock_calls()), 1, "exactly one request")
+  assert_eq(len(http_mock_calls()), 2, "release and tag identity are observed")
 }
 
 pipeline test_release_view_requires_exact_tag(task) {


### PR DESCRIPTION
Closes #183

Adds a typed, body-only GitHub release metadata mutation guarded by the exact release id, tag-ref object, and peeled tag target observed during lookup. The connector re-observes the complete lease immediately before mutation and returns a closed receipt.

No-network fixtures cover annotated-tag success, stale release and tag leases, missing releases, provider failure, exact body preservation, and proof that the PATCH cannot retag or modify assets.

Validation:
- `harn check --strict-types src tests/release_edit_body.harn tests/release_view.harn`
- `harn lint src`
- `harn fmt --check src tests`
- every `tests/*.harn` smoke run
- `harn test tests` (58 tests, 568 ms)
- `harn connector check .`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-github-connector/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787069904&installation_id=145974243&pr_number=184&repository=burin-labs%2Fharn-github-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-github-connector%2Fpull%2F184&signature=01861f91c9b8003e1ba1a87c7e6fda4e76e60a86361e1987822af97aec51e2f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->