### PR TITLE
Add a pure-Harn worktree-to-signed-commit adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,64 @@ Common auth options include `installation_token`,
 and `max_attempts`; `max_attempts` wins over wall-clock timeout to keep tests
 deterministic.
 
+## Worktree-to-signed-commit adapter
+
+`harn-github-connector/worktree` is a separate export that turns one exact
+local Git state into a GitHub-signed commit. It is the only part of this
+package that shells out to `git`; the default export stays a pure HTTP surface.
+
+```harn,ignore
+import {
+  GithubWorktreeCommitRequest,
+  github_commit_worktree,
+} from "harn-github-connector/worktree"
+
+const request: GithubWorktreeCommitRequest = {
+  owner: "octo-org",
+  repo: "octo-repo",
+  branch: "automation/bump",
+  headline: "Bump the pinned runtime",
+  repo_dir: "/path/to/checkout",
+  source: "worktree",
+  create_branch: true,
+  reset_branch: true,
+}
+const receipt = unwrap(github_commit_worktree(request, {installation_token: token}))
+```
+
+| Helper | Purpose |
+|---|---|
+| `github_worktree_delta(selector)` | Derive typed additions/deletions from an exact Git state. No network I/O. |
+| `github_commit_worktree(request, options)` | Derive, take the branch lease, publish through `github_create_signed_commit`, return one receipt. |
+
+Behavior worth knowing before you use it:
+
+- `source` is `"worktree"` (HEAD versus the full working tree, including
+  untracked non-ignored files, staged through a scratch `GIT_INDEX_FILE`) or
+  `"index"` (HEAD versus the caller's real index). Neither mutates the caller's
+  index or working tree.
+- `base_oid` must equal the local `HEAD`; it defaults to it. A payload derived
+  against a different tree would not describe the leased commit.
+- Renames become delete-old plus add-new. Blob bytes are preserved exactly,
+  binary included.
+- `createCommitOnBranch` carries only `path` and `contents`, so it cannot
+  *specify* a mode — but it does preserve the base tree entry's mode for a path
+  it already tracks. Modes are gated accordingly, always before any network
+  request:
+
+  | Case | Outcome |
+  |---|---|
+  | Tracked `100755` edited, mode unchanged | Published; GitHub keeps `100755` |
+  | New path with mode `100755` (added, copied, or a rename destination) | `unsupported_new_executable` |
+  | Mode changes between the base tree and the selected state | `unsupported_mode_change` |
+  | Symlink `120000` or submodule `160000` on either side | `unsupported_file_mode` |
+
+  Deletions carry no mode and are always supported.
+- An empty delta returns `committed: false`, `branch_action: "skipped"`, and
+  performs no network call.
+- A branch head that differs from the lease fails with `stale_head` unless
+  `reset_branch` is set.
+
 ## GitHub App setup
 
 Create a GitHub App and install it into the target account or repository set.

--- a/changelog.d/175.added.md
+++ b/changelog.d/175.added.md
@@ -1,0 +1,12 @@
+Added a pure-Harn worktree-to-signed-commit adapter, exported as
+`harn-github-connector/worktree`, so consumers stop assembling
+`createCommitOnBranch` payloads themselves. It derives typed additions and
+deletions from an exact Git state (worktree or index) without touching the
+caller's index, preserves exact blob bytes including binary, maps renames to
+delete-old plus add-new, takes the branch lease, and returns one receipt binding
+repository, branch, base, commit oid, changed paths with content digests, and
+GitHub's signature evidence. File modes are gated before any network request:
+editing a path already tracked at `100755` is published (the mutation preserves
+the base tree entry's mode), while a new executable, a mode change, and any
+symlink or submodule entry fail closed. Signed-commit additions now also accept
+genuinely empty file contents instead of failing as if the field were missing.

--- a/harn.toml
+++ b/harn.toml
@@ -8,6 +8,7 @@ harn = ">=0.10,<0.11"
 
 [exports]
 default = "src/lib.harn"
+worktree = "src/worktree_commit.harn"
 
 [[providers]]
 id = "github"

--- a/src/contracts.harn
+++ b/src/contracts.harn
@@ -16,6 +16,9 @@ pub type GithubConnectorError = {
   observed_tag_target_oid?: string,
   tag?: string,
   candidate_run_ids?: list<int>,
+  path?: string,
+  file_mode?: string,
+  base_file_mode?: string,
 }
 
 /** Canonical fallible boundary for every normalized GitHub operation. */
@@ -355,7 +358,7 @@ pub type GithubSignedCommitRequest = {
   branch: string,
   expected_head_oid: string,
   headline: string,
-  body?: string,
+  body?: string?,
   additions: list<GithubCommitFileAddition>,
   deletions: list<GithubCommitFileDeletion>,
 }
@@ -367,4 +370,101 @@ pub type GithubSignedCommitReceipt = {
   signature_valid: bool,
   signed_by_github: bool,
   signature_state: string,
+}
+
+/**
+ * One exact local Git state to derive a signed-commit payload from.
+ *
+ * `source` is `"worktree"` (the default: HEAD against the full working tree,
+ * tracked edits plus untracked non-ignored files, staged through a scratch
+ * index) or `"index"` (HEAD against the caller's real index, so only staged
+ * changes are published). Any other value fails with `schema_drift` before any
+ * work happens.
+ *
+ * `base_oid` is an optional pin that must equal the local `HEAD`: the derived
+ * payload only describes the leased commit when the two agree.
+ *
+ * Closed value sets are carried as `string` rather than string-literal unions
+ * because a literal union in a record field does not survive a cross-package
+ * import, which would make every consumer call site fail `harn check`. Import
+ * the type name itself (and any nested record type you construct) so record
+ * literals coerce to it.
+ */
+pub type GithubWorktreeSelector = {repo_dir: string, source?: string?, base_oid?: string?}
+
+/**
+ * One path-level change with the Git blob object id that carries its bytes.
+ *
+ * `status` is `"added"`, `"modified"`, or `"deleted"`. `blob_oid` is the Git
+ * blob object id — the content digest — of the bytes the change carries: the
+ * new content for `added`/`modified`, the removed content for `deleted`.
+ * `size_bytes` is that blob's exact byte length, and is `0` for a deletion.
+ * A rename appears as two changes: the `deleted` half carries `rename_to` and
+ * the `added` half carries `rename_from`.
+ */
+pub type GithubWorktreeChange = {
+  path: string,
+  status: string,
+  blob_oid: string,
+  size_bytes: int,
+  rename_from: string?,
+  rename_to: string?,
+}
+
+/** The typed additions/deletions request derived from one local Git state. */
+pub type GithubWorktreeDelta = {
+  repo_dir: string,
+  source: string,
+  base_oid: string,
+  empty: bool,
+  changes: list<GithubWorktreeChange>,
+  additions: list<GithubCommitFileAddition>,
+  deletions: list<GithubCommitFileDeletion>,
+}
+
+/**
+ * One worktree-to-signed-commit publication request.
+ *
+ * `create_branch` (default `true`) allows creating `refs/heads/<branch>` at
+ * `base_oid` when it does not exist. `reset_branch` (default `false`) allows
+ * force-resetting an existing branch back to `base_oid`; without it a branch
+ * head that differs from the lease fails closed with `stale_head`.
+ */
+pub type GithubWorktreeCommitRequest = {
+  owner: string,
+  repo: string,
+  branch: string,
+  headline: string,
+  body?: string?,
+  repo_dir: string,
+  source?: string?,
+  base_oid?: string?,
+  create_branch?: bool?,
+  reset_branch?: bool?,
+}
+
+/** GitHub's own signature evidence for the published commit. */
+pub type GithubWorktreeSignature = {verified: bool, signed_by_github: bool, state: string}
+
+/**
+ * One receipt binding repository, branch, lease, commit, and content digests.
+ *
+ * `branch_action` is `"skipped"` (empty delta, nothing published), `"unchanged"`,
+ * `"created"`, or `"reset"`. `committed` is `false` only for the empty-delta
+ * outcome, where `commit_oid` and `commit_url` are `""` and `signature` carries
+ * no evidence.
+ */
+pub type GithubWorktreeCommitReceipt = {
+  repository: string,
+  owner: string,
+  repo: string,
+  branch: string,
+  source: string,
+  base_oid: string,
+  committed: bool,
+  commit_oid: string,
+  commit_url: string,
+  branch_action: string,
+  changes: list<GithubWorktreeChange>,
+  signature: GithubWorktreeSignature,
 }

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -4395,10 +4395,11 @@ fn __github_signed_commit_additions(raw) {
   let seen = {}
   for item in raw {
     const path = trim(to_string(item?.path ?? ""))
-    const contents = trim(to_string(item?.contents_base64 ?? item?.contents ?? ""))
-    if path == "" || contents == "" {
+    const raw_contents = item?.contents_base64 ?? item?.contents
+    if path == "" || raw_contents == nil {
       return __err("schema_drift", "signed commit additions require path and contents_base64")
     }
+    const contents = trim(to_string(raw_contents))
     if seen.get(path) ?? false {
       return __err("schema_drift", "signed commit additions contain duplicate path `" + path + "`")
     }

--- a/src/worktree_commit.harn
+++ b/src/worktree_commit.harn
@@ -1,0 +1,874 @@
+/**
+ * Worktree-to-signed-commit adapter.
+ *
+ * `src/lib.harn` owns the HTTP/GraphQL provider surface, including the
+ * `github_create_signed_commit` primitive that atomically publishes typed
+ * additions and deletions under an `expected_head_oid` lease and accepts only a
+ * GitHub-generated signature. This module is the only place in the package that
+ * shells out to local `git`; it turns one exact local Git state into that typed
+ * request and returns one receipt.
+ *
+ * Responsibilities, in order:
+ *
+ * 1. Derive typed additions/deletions from an exact Git state without mutating
+ *    the caller's index or working tree. `source: "worktree"` builds a scratch
+ *    index (`GIT_INDEX_FILE`) so untracked, non-ignored files are included
+ *    without ever touching the real index; `source: "index"` reads the caller's
+ *    real index read-only.
+ * 2. Preserve exact blob bytes. Content never crosses the Harn string boundary
+ *    as text: `git cat-file blob | base64` produces the payload directly, and
+ *    the encoded length is checked against `git cat-file -s`.
+ * 3. Map renames to delete-old plus add-new.
+ * 4. Gate file modes against what the transport can actually carry, before any
+ *    network request. See `__wc_mode_gate` for the exact rule and its evidence.
+ * 5. Create or reset `refs/heads/<branch>` only under the exact base lease.
+ * 6. Call the existing `github_create_signed_commit` owner. This module never
+ *    writes its own `createCommitOnBranch` mutation.
+ * 7. Return one receipt binding repository, branch, base lease, commit oid,
+ *    changed paths with content digests, and GitHub's signature evidence.
+ *
+ * An empty delta is a clean outcome: `committed: false` with no network call.
+ */
+pub import {
+  GithubCommitFileAddition,
+  GithubCommitFileDeletion,
+  GithubConnectorError,
+  GithubConnectorResult,
+  GithubWorktreeChange,
+  GithubWorktreeCommitReceipt,
+  GithubWorktreeCommitRequest,
+  GithubWorktreeDelta,
+  GithubWorktreeSelector,
+  GithubWorktreeSignature,
+} from "./contracts"
+import { api_call, github_create_signed_commit } from "./lib"
+
+/** Git tree entry modes this adapter reasons about. */
+const WORKTREE_ABSENT_MODE = "000000"
+
+const WORKTREE_REGULAR_MODE = "100644"
+
+const WORKTREE_EXECUTABLE_MODE = "100755"
+
+const WORKTREE_SYMLINK_MODE = "120000"
+
+const WORKTREE_SUBMODULE_MODE = "160000"
+
+/** Per-command wall clock for local git plumbing. */
+const WORKTREE_GIT_TIMEOUT_MS = 120000
+
+/** NUL, the `-z` record separator used by every plumbing call below. */
+const WORKTREE_NUL = "\0"
+
+/** Lowercase hex digits accepted in a 40-character Git object id. */
+const WORKTREE_HEX = "0123456789abcdef"
+
+/** Characters accepted in an owner, repository, or branch path segment. */
+const WORKTREE_REF_ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-"
+
+fn __wc_category(code: string) -> string {
+  if code == "schema_drift" {
+    return "schema_drift"
+  }
+  if code == "stale_head" {
+    return "conflict"
+  }
+  return code
+}
+
+fn __wc_error(code: string, message: string, details = nil) -> GithubConnectorError {
+  const base = {code: code, category: __wc_category(code), message: message}
+  const error: GithubConnectorError = if details == nil {
+    base
+  } else {
+    base + details
+  }
+  return error
+}
+
+fn __wc_err(code: string, message: string, details = nil) {
+  return Err(__wc_error(code, message, details))
+}
+
+/** Re-type an inner failure so annotated boundaries keep one error contract. */
+fn __wc_error_of(result) -> GithubConnectorError {
+  const failure: GithubConnectorError = unwrap_err(result)
+  return failure
+}
+
+fn __wc_delta_result(result) -> GithubConnectorResult<GithubWorktreeDelta> {
+  if is_err(result) {
+    return Err(__wc_error_of(result))
+  }
+  const delta: GithubWorktreeDelta = unwrap(result)
+  return Ok(delta)
+}
+
+/** U+FFFD, the marker left behind when a path is not valid UTF-8. */
+fn __wc_replacement_char() -> string {
+  return base64_decode("77+9")
+}
+
+/**
+ * Owner, repository, and branch are interpolated into REST paths, so they are
+ * restricted to characters that cannot escape a path segment. `/` is allowed
+ * only in a branch name, where GitHub expects it as a literal ref separator.
+ */
+fn __wc_is_safe_ref(value: string, allow_slash: bool) -> bool {
+  if value == "" || starts_with(value, "-") || starts_with(value, "/") || ends_with(value, "/") {
+    return false
+  }
+  if contains(value, "..") || contains(value, "//") {
+    return false
+  }
+  const alphabet = if allow_slash {
+    WORKTREE_REF_ALPHABET + "/"
+  } else {
+    WORKTREE_REF_ALPHABET
+  }
+  for index in range(0, len(value)) {
+    if !contains(alphabet, substring(value, index, index + 1)) {
+      return false
+    }
+  }
+  return true
+}
+
+fn __wc_is_object_id(value: string) -> bool {
+  if len(value) != 40 {
+    return false
+  }
+  for index in range(0, 40) {
+    if !contains(WORKTREE_HEX, substring(value, index, index + 1)) {
+      return false
+    }
+  }
+  return true
+}
+
+fn __wc_run(spec: dict) {
+  const attempt = try {
+    spawn_captured(spec)
+  }
+  if is_err(attempt) {
+    return __wc_err("git", "local command failed: " + to_string(unwrap_err(attempt)))
+  }
+  const run = unwrap(attempt)
+  if !(run?.success ?? false) {
+    return __wc_err(
+      "git",
+      "local command `"
+        + to_string(spec?.cmd ?? "")
+        + "` failed with exit "
+        + to_string(run?.exit_code ?? -1)
+        + ": "
+        + trim(to_string(run?.stderr ?? "")),
+    )
+  }
+  return Ok(to_string(run?.stdout ?? ""))
+}
+
+fn __wc_git(repo_dir: string, args: list<string>, env: dict) {
+  return __wc_run(
+    {
+      cmd: "git",
+      args: args,
+      cwd: repo_dir,
+      env: env,
+      stdin: "",
+      timeout_ms: WORKTREE_GIT_TIMEOUT_MS,
+    },
+  )
+}
+
+fn __wc_git_line(repo_dir: string, args: list<string>, env: dict) {
+  const out = __wc_git(repo_dir, args, env)
+  if is_err(out) {
+    return out
+  }
+  return Ok(trim(unwrap(out)))
+}
+
+fn __wc_source(raw) -> string? {
+  const value = trim(to_string(raw ?? "worktree"))
+  if value == "" || value == "worktree" {
+    return "worktree"
+  }
+  if value == "index" {
+    return "index"
+  }
+  return nil
+}
+
+fn __wc_temp_dir() {
+  return __wc_run(
+    {
+      cmd: "sh",
+      args: [
+        "-c",
+        "root=\"$TMPDIR\"\ntest -n \"$root\" || root=/tmp\n"
+          + "mktemp -d \"$root/harn-github-connector-XXXXXX\"\n",
+      ],
+      stdin: "",
+      timeout_ms: WORKTREE_GIT_TIMEOUT_MS,
+    },
+  )
+}
+
+fn __wc_remove_dir(path: string) {
+  return __wc_run(
+    {
+      cmd: "sh",
+      args: ["-c", "rm -rf \"$HARN_WORKTREE_SCRATCH\""],
+      env: {HARN_WORKTREE_SCRATCH: path},
+      stdin: "",
+      timeout_ms: WORKTREE_GIT_TIMEOUT_MS,
+    },
+  )
+}
+
+/**
+ * Read one blob as `{size_bytes, contents_base64}`. The object id is passed
+ * through the environment, never interpolated into the shell script, and the
+ * encoded length is proven against `git cat-file -s` so a truncated or failed
+ * pipe can never masquerade as file content.
+ */
+fn __wc_blob(repo_dir: string, oid: string) {
+  if !__wc_is_object_id(oid) {
+    return __wc_err("git", "git reported a malformed blob object id `" + oid + "`")
+  }
+  const captured = __wc_run(
+    {
+      cmd: "sh",
+      args: [
+        "-c",
+        "git cat-file -s \"$HARN_WORKTREE_BLOB\" || exit 1\n"
+          + "git cat-file blob \"$HARN_WORKTREE_BLOB\" | base64 | tr -d '\\n'\n",
+      ],
+      cwd: repo_dir,
+      env: {HARN_WORKTREE_BLOB: oid},
+      stdin: "",
+      timeout_ms: WORKTREE_GIT_TIMEOUT_MS,
+    },
+  )
+  if is_err(captured) {
+    return captured
+  }
+  const lines = split(unwrap(captured), "\n")
+  const size = to_int(trim(lines[0]))
+  if size == nil {
+    return __wc_err("git", "git cat-file -s returned no size for blob `" + oid + "`")
+  }
+  const contents = if len(lines) > 1 {
+    trim(lines[1])
+  } else {
+    ""
+  }
+  if __wc_base64_bytes(contents) != size {
+    return __wc_err(
+      "git",
+      "blob `" + oid + "` did not survive base64 capture: expected " + to_string(size)
+        + " bytes",
+    )
+  }
+  return Ok({size_bytes: size, contents_base64: contents})
+}
+
+/** Exact decoded byte length of a canonical, unwrapped base64 payload. */
+fn __wc_base64_bytes(encoded: string) -> int {
+  const width = len(encoded)
+  if width == 0 {
+    return 0
+  }
+  if width % 4 != 0 {
+    return -1
+  }
+  const padding = if ends_with(encoded, "==") {
+    2
+  } else if ends_with(encoded, "=") {
+    1
+  } else {
+    0
+  }
+  return width / 4 * 3 - padding
+}
+
+fn __wc_tokens(raw: string) -> list<string> {
+  let tokens = []
+  for token in split(raw, WORKTREE_NUL) {
+    if token != "" {
+      tokens = tokens + [token]
+    }
+  }
+  return tokens
+}
+
+@complexity(allow)
+fn __wc_parse_raw(raw: string) {
+  const tokens = __wc_tokens(raw)
+  let entries = []
+  let cursor = 0
+  while cursor < len(tokens) {
+    const meta = to_string(tokens[cursor] ?? "")
+    if !starts_with(meta, ":") {
+      return __wc_err("git", "unexpected `git diff-index --raw -z` record `" + meta + "`")
+    }
+    const fields = split(substring(meta, 1, len(meta)), " ")
+    if len(fields) < 5 {
+      return __wc_err("git", "unexpected `git diff-index --raw -z` record `" + meta + "`")
+    }
+    const status = substring(uppercase(to_string(fields[4] ?? "")), 0, 1)
+    const paths = if status == "R" || status == "C" {
+      2
+    } else {
+      1
+    }
+    if cursor + paths >= len(tokens) {
+      return __wc_err("git", "truncated `git diff-index --raw -z` record `" + meta + "`")
+    }
+    entries = entries
+      + [
+      {
+        src_mode: to_string(fields[0] ?? ""),
+        dst_mode: to_string(fields[1] ?? ""),
+        src_oid: lowercase(to_string(fields[2] ?? "")),
+        dst_oid: lowercase(to_string(fields[3] ?? "")),
+        status: status,
+        src_path: to_string(tokens[cursor + 1] ?? ""),
+        dst_path: to_string(tokens[cursor + paths] ?? ""),
+      },
+    ]
+    cursor = cursor + 1 + paths
+  }
+  return Ok(entries)
+}
+
+fn __wc_check_paths(entries) {
+  const replacement = __wc_replacement_char()
+  for entry in entries {
+    for path in [entry.src_path, entry.dst_path] {
+      if contains(path, replacement) {
+        return __wc_err(
+          "unsupported_path",
+          "path `" + path + "` is not valid UTF-8 and cannot be published exactly",
+          {path: path},
+        )
+      }
+    }
+  }
+  return Ok(true)
+}
+
+fn __wc_deletion(path: string, oid: string, rename_to) -> GithubWorktreeChange {
+  return {
+    path: path,
+    status: "deleted",
+    blob_oid: oid,
+    size_bytes: 0,
+    rename_from: nil,
+    rename_to: rename_to,
+  }
+}
+
+fn __wc_addition(repo_dir: string, path: string, oid: string, status: string, rename_from) {
+  const blob = __wc_blob(repo_dir, oid)
+  if is_err(blob) {
+    return blob
+  }
+  const content = unwrap(blob)
+  return Ok(
+    {
+      change: {
+        path: path,
+        status: status,
+        blob_oid: oid,
+        size_bytes: content.size_bytes,
+        rename_from: rename_from,
+        rename_to: nil,
+      },
+      contents_base64: content.contents_base64,
+    },
+  )
+}
+
+/**
+ * Decide whether one written tree entry can be published faithfully.
+ *
+ * `FileAddition` exposes only `path` and `contents`, so the mutation cannot
+ * *specify* a mode. It does not follow that it *clobbers* one: a commit created
+ * by `createCommitOnBranch` over a path already in the base tree keeps that
+ * entry's mode. Evidence — burin-labs/burin-code `9ec6ffb`, committed
+ * server-side by `GitHub <noreply@github.com>` through that mutation, has
+ * `git diff-tree -r` records `:100755 100755 … M scripts/ci-rustc-wrapper.sh`.
+ * A blanket "reject every non-100644 entry" rule would therefore refuse cases
+ * the transport handles correctly, which for an agent editing shell scripts is
+ * a hard failure on an otherwise working path.
+ *
+ * The rule, still fail-closed, keyed on the base-tree mode that
+ * `git diff-index --raw` reports on the source side (`000000` means the path is
+ * absent from the base tree):
+ *
+ * - symlink (`120000`) or submodule (`160000`) on either side: always rejected.
+ *   Sending a symlink as an addition writes a regular file holding the link
+ *   target's bytes; writing over a symlink entry inherits `120000` and turns
+ *   file content into a link target. Both silently destroy the tree.
+ * - executable (`100755`) on a path already in the base tree at `100755`:
+ *   accepted, because the mode is preserved.
+ * - executable on a path new to the base tree (added, copied, or a rename
+ *   destination): rejected. There is no prior entry to inherit from, so it
+ *   would land `100644`. This one is not empirically confirmed — a committed
+ *   tree keeps no record of what the author intended — so it fails closed.
+ * - any mode change between the base tree and the selected state: rejected,
+ *   because the transport cannot carry the chmod and would silently no-op it.
+ *
+ * Deletions carry no mode and are handled before this gate; removing an entry
+ * of any mode is supported.
+ */
+@complexity(allow)
+fn __wc_mode_gate(entry) {
+  const base_mode = entry.src_mode
+  const mode = entry.dst_mode
+  const path = entry.dst_path
+  const evidence = {path: path, file_mode: mode, base_file_mode: base_mode}
+  for unsupported in [WORKTREE_SYMLINK_MODE, WORKTREE_SUBMODULE_MODE] {
+    if mode == unsupported || base_mode == unsupported {
+      return __wc_err(
+        "unsupported_file_mode",
+        "path `" + path + "` involves Git mode " + unsupported
+          + ", which GitHub's createCommitOnBranch transport cannot represent; publishing it "
+          + "would silently commit a different tree entry",
+        evidence,
+      )
+    }
+  }
+  if mode != WORKTREE_REGULAR_MODE && mode != WORKTREE_EXECUTABLE_MODE {
+    return __wc_err(
+      "unsupported_file_mode",
+      "path `" + path + "` has unrecognized Git mode " + mode,
+      evidence,
+    )
+  }
+  const new_path = entry.status == "R" || entry.status == "C"
+    || base_mode == WORKTREE_ABSENT_MODE
+  if new_path {
+    if mode == WORKTREE_EXECUTABLE_MODE {
+      return __wc_err(
+        "unsupported_new_executable",
+        "path `" + path
+          + "` is new to the base tree and executable; createCommitOnBranch cannot set a mode on "
+          + "a path it is creating, so the commit would land it as "
+          + WORKTREE_REGULAR_MODE,
+        evidence,
+      )
+    }
+    return Ok(true)
+  }
+  if base_mode != mode {
+    return __wc_err(
+      "unsupported_mode_change",
+      "path `" + path + "` changes Git mode from " + base_mode + " to " + mode
+        + "; createCommitOnBranch preserves the base tree entry's mode, so the change would be "
+        + "silently dropped",
+      evidence,
+    )
+  }
+  return Ok(true)
+}
+
+@complexity(allow)
+fn __wc_classify(repo_dir: string, entries) {
+  let changes = []
+  let contents = {}
+  for entry in entries {
+    const status = entry.status
+    if status == "U" || status == "X" {
+      return __wc_err(
+        "git",
+        "path `" + entry.dst_path + "` is unmerged or unclassifiable (`" + status
+          + "`); resolve it before publishing a signed commit",
+        {path: entry.dst_path},
+      )
+    }
+    if status == "D" {
+      changes = changes + [__wc_deletion(entry.src_path, entry.src_oid, nil)]
+      continue
+    }
+    const gated = __wc_mode_gate(entry)
+    if is_err(gated) {
+      return gated
+    }
+    const renamed = status == "R"
+    if renamed {
+      changes = changes + [__wc_deletion(entry.src_path, entry.src_oid, entry.dst_path)]
+    }
+    const label = if status == "A" || status == "C" || renamed {
+      "added"
+    } else {
+      "modified"
+    }
+    const added = __wc_addition(
+      repo_dir,
+      entry.dst_path,
+      entry.dst_oid,
+      label,
+      if renamed {
+        entry.src_path
+      } else {
+        nil
+      },
+    )
+    if is_err(added) {
+      return added
+    }
+    const record = unwrap(added)
+    changes = changes + [record.change]
+    contents[entry.dst_path] = record.contents_base64
+  }
+  return Ok({changes: changes, contents: contents})
+}
+
+/**
+ * Drop deletions for paths the same commit also writes. Git reports a swap
+ * (`a -> b` plus `b -> a`) as two renames, and `createCommitOnBranch` rejects a
+ * payload that both adds and deletes one path; the write is the correct outcome.
+ */
+fn __wc_resolve(changes: list<GithubWorktreeChange>) -> list<GithubWorktreeChange> {
+  let written = {}
+  for change in changes {
+    if change.status != "deleted" {
+      written[change.path] = true
+    }
+  }
+  let resolved = []
+  for change in changes {
+    if change.status == "deleted" && (written.get(change.path) ?? false) {
+      continue
+    }
+    resolved = resolved + [change]
+  }
+  return resolved
+}
+
+fn __wc_payload(changes: list<GithubWorktreeChange>, contents: dict) {
+  let additions: list<GithubCommitFileAddition> = []
+  let deletions: list<GithubCommitFileDeletion> = []
+  for change in changes {
+    if change.status == "deleted" {
+      deletions = deletions + [{path: change.path}]
+      continue
+    }
+    additions = additions
+      + [
+      {path: change.path, contents_base64: to_string(contents.get(change.path) ?? "")},
+    ]
+  }
+  return {additions: additions, deletions: deletions}
+}
+
+fn __wc_scratch_index(repo_dir: string, scratch: string) {
+  const env = {GIT_INDEX_FILE: scratch + "/index"}
+  const seeded = __wc_git(repo_dir, ["read-tree", "HEAD"], env)
+  if is_err(seeded) {
+    return seeded
+  }
+  const staged = __wc_git(repo_dir, ["add", "--all"], env)
+  if is_err(staged) {
+    return staged
+  }
+  return Ok(env)
+}
+
+fn __wc_raw_diff(repo_dir: string, base_oid: string, env: dict) {
+  return __wc_git(
+    repo_dir,
+    ["diff-index", "--cached", "--raw", "-z", "-M", "--no-abbrev", base_oid],
+    env,
+  )
+}
+
+fn __wc_base_oid(repo_dir: string, requested) {
+  const head = __wc_git_line(repo_dir, ["rev-parse", "HEAD"], {})
+  if is_err(head) {
+    return head
+  }
+  const observed = lowercase(unwrap(head))
+  if !__wc_is_object_id(observed) {
+    return __wc_err("git", "`git rev-parse HEAD` returned `" + observed + "`")
+  }
+  const pinned = lowercase(trim(to_string(requested ?? "")))
+  if pinned != "" && pinned != observed {
+    return __wc_err(
+      "stale_head",
+      "requested base oid does not match the local repository HEAD, so the derived payload would "
+        + "not describe the leased commit",
+      {expected_head_oid: pinned, observed_head_oid: observed},
+    )
+  }
+  return Ok(observed)
+}
+
+fn __wc_delta_env(repo_dir: string, source: string, scratch) {
+  if source == "index" {
+    return Ok({})
+  }
+  if scratch == nil {
+    return __wc_err("git", "worktree selection requires a scratch index directory")
+  }
+  return __wc_scratch_index(repo_dir, to_string(scratch))
+}
+
+@complexity(allow)
+fn __wc_delta(repo_dir: string, source: string, requested_base, scratch) {
+  const base = __wc_base_oid(repo_dir, requested_base)
+  if is_err(base) {
+    return base
+  }
+  const base_oid = unwrap(base)
+  const env = __wc_delta_env(repo_dir, source, scratch)
+  if is_err(env) {
+    return env
+  }
+  const raw = __wc_raw_diff(repo_dir, base_oid, unwrap(env))
+  if is_err(raw) {
+    return raw
+  }
+  const parsed = __wc_parse_raw(unwrap(raw))
+  if is_err(parsed) {
+    return parsed
+  }
+  const entries = unwrap(parsed)
+  const paths_ok = __wc_check_paths(entries)
+  if is_err(paths_ok) {
+    return paths_ok
+  }
+  const classified = __wc_classify(repo_dir, entries)
+  if is_err(classified) {
+    return classified
+  }
+  const result = unwrap(classified)
+  const changes = __wc_resolve(result.changes)
+  const payload = __wc_payload(changes, result.contents)
+  const delta: GithubWorktreeDelta = {
+    repo_dir: repo_dir,
+    source: source,
+    base_oid: base_oid,
+    empty: len(changes) == 0,
+    changes: changes,
+    additions: payload.additions,
+    deletions: payload.deletions,
+  }
+  return Ok(delta)
+}
+
+/**
+ * Derive one typed additions/deletions payload from an exact local Git state.
+ *
+ * This performs no network I/O and never mutates the caller's index or working
+ * tree. `source: "worktree"` (the default) stages the full working tree into a
+ * scratch index under a temporary directory; `source: "index"` reads the
+ * caller's real index read-only. Non-`100644` destination modes and unmerged
+ * entries fail here, before any caller can reach the network.
+ */
+pub fn github_worktree_delta(
+  selector: GithubWorktreeSelector,
+) -> GithubConnectorResult<GithubWorktreeDelta> {
+  const repo_dir = trim(to_string(selector.repo_dir ?? ""))
+  if repo_dir == "" {
+    return __wc_err("schema_drift", "worktree selector requires `repo_dir`")
+  }
+  const source = __wc_source(selector.source)
+  if source == nil {
+    return __wc_err(
+      "schema_drift",
+      "worktree selector `source` must be `worktree` or `index`, got `"
+        + to_string(selector.source)
+        + "`",
+    )
+  }
+  if source == "index" {
+    return __wc_delta_result(__wc_delta(repo_dir, source, selector.base_oid, nil))
+  }
+  const scratch = __wc_temp_dir()
+  if is_err(scratch) {
+    return Err(__wc_error_of(scratch))
+  }
+  const scratch_dir = trim(unwrap(scratch))
+  const delta = __wc_delta(repo_dir, source, selector.base_oid, scratch_dir)
+  __wc_remove_dir(scratch_dir)
+  return __wc_delta_result(delta)
+}
+
+fn __wc_ref_path(request: GithubWorktreeCommitRequest, prefix: string) -> string {
+  return "/repos/" + request.owner + "/" + request.repo + prefix + request.branch
+}
+
+@complexity(allow)
+fn __wc_branch_lease(request: GithubWorktreeCommitRequest, base_oid: string, options: dict) {
+  const lookup = api_call(__wc_ref_path(request, "/git/ref/heads/"), "GET", nil, options)
+  if is_err(lookup) {
+    const failure: GithubConnectorError = unwrap_err(lookup)
+    if (failure.http_status ?? 0) != 404 {
+      return Err(failure)
+    }
+    if !(request.create_branch ?? true) {
+      return __wc_err(
+        "stale_head",
+        "branch `" + request.branch + "` does not exist and `create_branch` is disabled",
+        {expected_head_oid: base_oid, observed_head_oid: ""},
+      )
+    }
+    const created = api_call(
+      "/repos/" + request.owner + "/" + request.repo + "/git/refs",
+      "POST",
+      {ref: "refs/heads/" + request.branch, sha: base_oid},
+      options,
+    )
+    if is_err(created) {
+      return created
+    }
+    return Ok("created")
+  }
+  const reference: dict = unwrap(lookup)
+  const observed = lowercase(trim(to_string(reference?.object?.sha ?? "")))
+  if observed == base_oid {
+    return Ok("unchanged")
+  }
+  if !(request.reset_branch ?? false) {
+    return __wc_err(
+      "stale_head",
+      "branch `" + request.branch + "` is at " + observed + " but the lease requires " + base_oid
+        + "; enable `reset_branch` to force it back to the base",
+      {expected_head_oid: base_oid, observed_head_oid: observed},
+    )
+  }
+  const reset = api_call(
+    __wc_ref_path(request, "/git/refs/heads/"),
+    "PATCH",
+    {sha: base_oid, force: true},
+    options,
+  )
+  if is_err(reset) {
+    return reset
+  }
+  return Ok("reset")
+}
+
+fn __wc_validate(request: GithubWorktreeCommitRequest) {
+  const required = [request.owner, request.repo, request.branch, request.headline, request.repo_dir]
+  for value in required {
+    if trim(to_string(value ?? "")) == "" {
+      return __wc_err(
+        "schema_drift",
+        "github_commit_worktree requires owner, repo, branch, headline, and repo_dir",
+      )
+    }
+  }
+  if !__wc_is_safe_ref(request.owner, false) || !__wc_is_safe_ref(request.repo, false) {
+    return __wc_err(
+      "schema_drift",
+      "`" + request.owner + "/" + request.repo + "` is not a usable GitHub repository name",
+    )
+  }
+  if !__wc_is_safe_ref(request.branch, true) {
+    return __wc_err(
+      "schema_drift",
+      "branch `" + request.branch + "` is not a usable automation branch name",
+    )
+  }
+  return Ok(true)
+}
+
+fn __wc_empty_receipt(
+  request: GithubWorktreeCommitRequest,
+  delta: GithubWorktreeDelta,
+) -> GithubWorktreeCommitReceipt {
+  return {
+    repository: request.owner + "/" + request.repo,
+    owner: request.owner,
+    repo: request.repo,
+    branch: request.branch,
+    source: delta.source,
+    base_oid: delta.base_oid,
+    committed: false,
+    commit_oid: "",
+    commit_url: "",
+    branch_action: "skipped",
+    changes: [],
+    signature: {verified: false, signed_by_github: false, state: ""},
+  }
+}
+
+/**
+ * Publish one exact local Git state to `branch` as a GitHub-signed commit.
+ *
+ * The payload is derived first and entirely locally, so an unsupported file
+ * mode fails before any network request. The branch is then created or reset
+ * only to `base_oid` (which must equal the local `HEAD`), and the commit is
+ * published through `github_create_signed_commit`, which rejects any response
+ * without a valid GitHub-generated signature.
+ *
+ * An empty delta returns `committed: false` with `branch_action: "skipped"` and
+ * performs no network call at all.
+ */
+@complexity(allow)
+pub fn github_commit_worktree(
+  request: GithubWorktreeCommitRequest,
+  options = nil,
+) -> GithubConnectorResult<GithubWorktreeCommitReceipt> {
+  const opts = options ?? {}
+  const valid = __wc_validate(request)
+  if is_err(valid) {
+    return Err(__wc_error_of(valid))
+  }
+  const derived = github_worktree_delta(
+    {repo_dir: request.repo_dir, source: request.source, base_oid: request.base_oid},
+  )
+  if is_err(derived) {
+    return Err(__wc_error_of(derived))
+  }
+  const delta: GithubWorktreeDelta = unwrap(derived)
+  if delta.empty {
+    return Ok(__wc_empty_receipt(request, delta))
+  }
+  const lease = __wc_branch_lease(request, delta.base_oid, opts)
+  if is_err(lease) {
+    return Err(__wc_error_of(lease))
+  }
+  const branch_action = to_string(unwrap(lease))
+  const published = github_create_signed_commit(
+    {
+      owner: request.owner,
+      repo: request.repo,
+      branch: request.branch,
+      expected_head_oid: delta.base_oid,
+      headline: request.headline,
+      body: request.body,
+      additions: delta.additions,
+      deletions: delta.deletions,
+    },
+    opts,
+  )
+  if is_err(published) {
+    return Err(__wc_error_of(published))
+  }
+  const commit = unwrap(published)
+  const receipt: GithubWorktreeCommitReceipt = {
+    repository: request.owner + "/" + request.repo,
+    owner: request.owner,
+    repo: request.repo,
+    branch: commit.branch,
+    source: delta.source,
+    base_oid: delta.base_oid,
+    committed: true,
+    commit_oid: commit.oid,
+    commit_url: commit.url,
+    branch_action: branch_action,
+    changes: delta.changes,
+    signature: {
+      verified: commit.signature_valid,
+      signed_by_github: commit.signed_by_github,
+      state: commit.signature_state,
+    },
+  }
+  return Ok(receipt)
+}

--- a/tests/worktree_commit.harn
+++ b/tests/worktree_commit.harn
@@ -1,0 +1,775 @@
+import {
+  GithubWorktreeCommitRequest,
+  GithubWorktreeSelector,
+  github_commit_worktree,
+  github_worktree_delta,
+} from "../src/worktree_commit"
+
+const GITHUB_BASE = "https://api.github.test"
+
+const OWNER = "octo-org"
+
+const REPO = "octo-repo"
+
+const BRANCH = "automation/worktree"
+
+const COMMIT_OID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+const OTHER_OID = "cccccccccccccccccccccccccccccccccccccccc"
+
+/**
+ * Repo-local config only. The fixture must not inherit the developer's global
+ * ignore/attribute/signing settings, or a passing run would prove nothing about
+ * a clean CI machine.
+ */
+const GIT_INIT = """
+set -e
+git init -q -b main .
+git config user.email harn-worktree-test@example.test
+git config user.name "Harn Worktree Test"
+git config commit.gpgsign false
+git config core.excludesFile /dev/null
+git config core.attributesFile /dev/null
+git config core.autocrlf false
+git config core.hooksPath .git/harn-absent-hooks
+git config core.fileMode true
+printf 'hello\n' > keep.txt
+printf 'a rename source long enough to be uninteresting to any other pairing\n' > old.txt
+printf 'delete me\n' > gone.txt
+printf '#!/bin/sh\necho base\n' > tool.sh
+chmod 755 tool.sh
+ln -s keep.txt tracked-link.txt
+git add -A
+git commit -q --no-verify -m base
+"""
+
+fn expect(condition: bool, message: string) {
+  if !condition {
+    throw message
+  }
+}
+
+fn expect_text(observed: string, wanted: string, label: string) {
+  if observed != wanted {
+    throw label + ": expected `" + wanted + "`, observed `" + observed + "`"
+  }
+}
+
+fn run_ok(spec: dict) -> dict {
+  const result = spawn_captured(spec)
+  if result.success != true {
+    throw "fixture command failed with exit " + to_string(result.exit_code) + ": "
+      + to_string(
+      result.stderr,
+    )
+  }
+  return result
+}
+
+fn sh_out(dir: string, script: string, env: dict = {}) -> string {
+  return to_string(
+    run_ok({cmd: "sh", args: ["-c", script], cwd: dir, env: env, stdin: "", timeout_ms: 120000})
+      .stdout,
+  )
+}
+
+fn sh_run(dir: string, script: string, env: dict = {}) {
+  run_ok({cmd: "sh", args: ["-c", script], cwd: dir, env: env, stdin: "", timeout_ms: 120000})
+}
+
+fn temp_dir() -> string {
+  return trim(
+    sh_out(
+      "/",
+      """
+root="$TMPDIR"
+test -n "$root" || root=/tmp
+mktemp -d "$root/harn-worktree-commit-XXXXXX"
+""",
+    ),
+  )
+}
+
+fn new_repo() -> string {
+  const dir = temp_dir()
+  sh_run(dir, GIT_INIT)
+  return dir
+}
+
+fn drop_repo(dir: string) {
+  sh_run("/", "rm -rf \"$HARN_FIXTURE_DIR\"", {HARN_FIXTURE_DIR: dir})
+}
+
+fn head_oid(dir: string) -> string {
+  return trim(sh_out(dir, "git rev-parse HEAD"))
+}
+
+/** Everything a caller would notice if the adapter touched the repo. */
+fn repo_state(dir: string) -> string {
+  return sh_out(
+    dir,
+    "git rev-parse HEAD\ngit status --porcelain\ngit ls-files -s\ngit rev-parse --abbrev-ref HEAD\n",
+  )
+}
+
+fn blob_oid(dir: string, path: string) -> string {
+  return trim(sh_out(dir, "git hash-object \"$HARN_FIXTURE_PATH\"", {HARN_FIXTURE_PATH: path}))
+}
+
+fn options() -> dict {
+  return {api_base_url: GITHUB_BASE, installation_token: "github-app-installation-token"}
+}
+
+fn ref_url(branch: string) -> string {
+  return GITHUB_BASE + "/repos/" + OWNER + "/" + REPO + "/git/ref/heads/" + branch
+}
+
+fn refs_url() -> string {
+  return GITHUB_BASE + "/repos/" + OWNER + "/" + REPO + "/git/refs"
+}
+
+fn ref_update_url(branch: string) -> string {
+  return GITHUB_BASE + "/repos/" + OWNER + "/" + REPO + "/git/refs/heads/" + branch
+}
+
+fn mock_ref_at(sha: string) {
+  http_mock(
+    "GET",
+    ref_url(BRANCH),
+    {
+      status: 200,
+      body: json_stringify({ref: "refs/heads/" + BRANCH, object: {sha: sha, type: "commit"}}),
+    },
+  )
+}
+
+fn mock_ref_missing() {
+  http_mock("GET", ref_url(BRANCH), {status: 404, body: json_stringify({message: "Not Found"})})
+}
+
+fn mock_ref_create() {
+  http_mock("POST", refs_url(), {status: 201, body: json_stringify({ref: "refs/heads/" + BRANCH})})
+}
+
+fn mock_ref_reset() {
+  http_mock(
+    "PATCH",
+    ref_update_url(BRANCH),
+    {status: 200, body: json_stringify({ref: "refs/heads/" + BRANCH})},
+  )
+}
+
+fn commit_body(signed: bool) -> string {
+  return json_stringify(
+    {
+      data: {
+        createCommitOnBranch: {
+          commit: {
+            oid: COMMIT_OID,
+            url: "https://github.com/" + OWNER + "/" + REPO + "/commit/" + COMMIT_OID,
+            signature: if signed {
+              {isValid: true, state: "VALID", wasSignedByGitHub: true}
+            } else {
+              {isValid: false, state: "UNSIGNED", wasSignedByGitHub: false}
+            },
+          },
+          ref: {name: BRANCH, target: {oid: COMMIT_OID}},
+        },
+      },
+    },
+  )
+}
+
+fn mock_commit(signed: bool) {
+  http_mock("POST", GITHUB_BASE + "/graphql", {status: 200, body: commit_body(signed)})
+}
+
+/** Fail loudly on any request the test did not deliberately allow. */
+fn mock_forbid_everything() {
+  for method in ["GET", "POST", "PATCH", "PUT", "DELETE"] {
+    http_mock(
+      method,
+      GITHUB_BASE + "/*",
+      {status: 500, body: json_stringify({message: "unexpected request"})},
+    )
+  }
+}
+
+fn request_for(dir: string, source: string?, reset_branch: bool) -> GithubWorktreeCommitRequest {
+  return {
+    owner: OWNER,
+    repo: REPO,
+    branch: BRANCH,
+    headline: "Publish worktree",
+    body: "Derived by the worktree adapter",
+    repo_dir: dir,
+    source: source,
+    base_oid: nil,
+    create_branch: true,
+    reset_branch: reset_branch,
+  }
+}
+
+fn request_for_branch(dir: string, branch: string) -> GithubWorktreeCommitRequest {
+  return {
+    owner: OWNER,
+    repo: REPO,
+    branch: branch,
+    headline: "Publish worktree",
+    body: nil,
+    repo_dir: dir,
+    source: "worktree",
+    base_oid: nil,
+    create_branch: true,
+    reset_branch: false,
+  }
+}
+
+fn graphql_calls() -> list<dict> {
+  let out = []
+  for call in http_mock_calls() {
+    if to_string(call.method) == "POST" && ends_with(to_string(call.url), "/graphql") {
+      out = out + [call]
+    }
+  }
+  return out
+}
+
+fn graphql_input() -> dict {
+  const calls = graphql_calls()
+  if len(calls) != 1 {
+    throw "expected exactly one createCommitOnBranch request, observed " + to_string(len(calls))
+  }
+  const payload: dict = json_parse(to_string(calls[0].body))
+  return payload.variables.input
+}
+
+fn field_paths(items) -> list<string> {
+  let out = []
+  for item in items {
+    out = out + [to_string(item.path)]
+  }
+  return out
+}
+
+fn addition_contents(input: dict, path: string) -> string {
+  for item in input.fileChanges.additions {
+    if to_string(item.path) == path {
+      return to_string(item.contents)
+    }
+  }
+  throw "the observed request carried no addition for `" + path + "`"
+}
+
+fn change_named(changes, path: string) -> dict {
+  for change in changes {
+    if to_string(change.path) == path {
+      return change
+    }
+  }
+  throw "the receipt carried no change for `" + path + "`"
+}
+
+fn change_paths(changes) -> list<string> {
+  let out = []
+  for change in changes {
+    out = out + [to_string(change.path) + ":" + to_string(change.status)]
+  }
+  return out
+}
+
+pipeline test_worktree_commit_publishes_modified_added_deleted_and_renamed_paths(task) {
+  http_mock_clear()
+  const dir = new_repo()
+  sh_run(
+    dir,
+    """
+set -e
+printf 'hello world\n' > keep.txt
+mv old.txt new.txt
+rm gone.txt
+printf 'brand new\n' > added.txt
+: > empty.txt
+""",
+  )
+  const base = head_oid(dir)
+  mock_ref_at(base)
+  mock_commit(true)
+  const result = github_commit_worktree(request_for(dir, "worktree", false), options())
+  expect(!is_err(result), "worktree commit succeeded")
+  const receipt = unwrap(result)
+  assert_eq(receipt.committed, true, "commit published")
+  assert_eq(receipt.repository, OWNER + "/" + REPO, "receipt repository")
+  assert_eq(receipt.branch, BRANCH, "receipt branch")
+  assert_eq(receipt.base_oid, base, "receipt base lease")
+  assert_eq(receipt.commit_oid, COMMIT_OID, "receipt commit oid")
+  assert_eq(receipt.branch_action, "unchanged", "branch already at the lease")
+  assert_eq(receipt.signature.verified, true, "GitHub signature verified")
+  assert_eq(receipt.signature.signed_by_github, true, "GitHub generated the signature")
+  assert_eq(receipt.signature.state, "VALID", "signature state")
+  assert_eq(
+    change_paths(receipt.changes),
+    [
+      "added.txt:added",
+      "empty.txt:added",
+      "gone.txt:deleted",
+      "keep.txt:modified",
+      "old.txt:deleted",
+      "new.txt:added",
+    ],
+    "receipt changes",
+  )
+  assert_eq(change_named(receipt.changes, "new.txt").rename_from, "old.txt", "rename destination")
+  assert_eq(change_named(receipt.changes, "old.txt").rename_to, "new.txt", "rename source")
+  assert_eq(
+    change_named(receipt.changes, "keep.txt").blob_oid,
+    blob_oid(dir, "keep.txt"),
+    "content digest for the modified path",
+  )
+  assert_eq(change_named(receipt.changes, "keep.txt").size_bytes, 12, "modified path size")
+  assert_eq(change_named(receipt.changes, "empty.txt").size_bytes, 0, "empty file size")
+  const input = graphql_input()
+  assert_eq(input.expectedHeadOid, base, "expected head lease")
+  assert_eq(input.branch.repositoryNameWithOwner, OWNER + "/" + REPO, "mutation repository")
+  assert_eq(
+    field_paths(input.fileChanges.additions),
+    ["added.txt", "empty.txt", "keep.txt", "new.txt"],
+    "mutation additions",
+  )
+  assert_eq(field_paths(input.fileChanges.deletions), ["gone.txt", "old.txt"], "mutation deletions")
+  assert_eq(
+    addition_contents(input, "keep.txt"),
+    base64_encode("hello world\n"),
+    "modified content",
+  )
+  assert_eq(addition_contents(input, "empty.txt"), "", "empty file content")
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+pipeline test_worktree_commit_preserves_exact_binary_bytes(task) {
+  http_mock_clear()
+  const dir = new_repo()
+  sh_run(
+    dir,
+    """
+set -e
+printf 'PNG\000\001\002\377\376\015\012 binary\200 payload\000' > payload.bin
+""",
+  )
+  const base = head_oid(dir)
+  mock_ref_at(base)
+  mock_commit(true)
+  const result = github_commit_worktree(request_for(dir, "worktree", false), options())
+  expect(!is_err(result), "binary worktree commit succeeded")
+  const receipt = unwrap(result)
+  assert_eq(change_paths(receipt.changes), ["payload.bin:added"], "binary change")
+  assert_eq(
+    change_named(receipt.changes, "payload.bin").blob_oid,
+    blob_oid(dir, "payload.bin"),
+    "binary content digest",
+  )
+  assert_eq(change_named(receipt.changes, "payload.bin").size_bytes, 27, "binary byte count")
+  const contents = addition_contents(graphql_input(), "payload.bin")
+  sh_run(
+    dir,
+    """
+set -e
+printf '%s' "$HARN_OBSERVED_BASE64" | base64 -d > roundtrip.bin
+cmp roundtrip.bin payload.bin
+""",
+    {HARN_OBSERVED_BASE64: contents},
+  )
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+pipeline test_index_selector_publishes_only_staged_changes(task) {
+  http_mock_clear()
+  const dir = new_repo()
+  sh_run(
+    dir,
+    """
+set -e
+printf 'staged\n' > keep.txt
+git add keep.txt
+printf 'unstaged\n' > gone.txt
+printf 'untracked\n' > extra.txt
+""",
+  )
+  const base = head_oid(dir)
+  mock_ref_at(base)
+  mock_commit(true)
+  const staged = github_worktree_delta({repo_dir: dir, source: "index", base_oid: base})
+  expect(!is_err(staged), "staged delta derived")
+  assert_eq(change_paths(unwrap(staged).changes), ["keep.txt:modified"], "staged-only delta")
+  const worktree = github_worktree_delta({repo_dir: dir, source: "worktree", base_oid: base})
+  expect(!is_err(worktree), "worktree delta derived")
+  assert_eq(
+    change_paths(unwrap(worktree).changes),
+    ["extra.txt:added", "gone.txt:modified", "keep.txt:modified"],
+    "worktree delta",
+  )
+  const result = github_commit_worktree(request_for(dir, "index", false), options())
+  expect(!is_err(result), "staged commit succeeded")
+  assert_eq(unwrap(result).source, "index", "receipt records the selector")
+  const input = graphql_input()
+  assert_eq(field_paths(input.fileChanges.additions), ["keep.txt"], "staged additions only")
+  assert_eq(field_paths(input.fileChanges.deletions), [], "no deletions")
+  assert_eq(addition_contents(input, "keep.txt"), base64_encode("staged\n"), "staged content")
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+pipeline test_empty_delta_is_a_clean_outcome_with_no_network_call(task) {
+  http_mock_clear()
+  mock_forbid_everything()
+  const dir = new_repo()
+  const base = head_oid(dir)
+  const result = github_commit_worktree(request_for(dir, "worktree", false), options())
+  expect(!is_err(result), "empty delta is not an error")
+  const receipt = unwrap(result)
+  assert_eq(receipt.committed, false, "nothing was committed")
+  assert_eq(receipt.branch_action, "skipped", "branch untouched")
+  assert_eq(receipt.commit_oid, "", "no commit oid")
+  assert_eq(receipt.base_oid, base, "receipt still binds the base")
+  assert_eq(receipt.changes, [], "no changes")
+  assert_eq(receipt.signature.verified, false, "no signature evidence")
+  assert_eq(len(http_mock_calls()), 0, "no network request at all")
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+pipeline test_stale_branch_head_fails_closed_before_any_mutation(task) {
+  http_mock_clear()
+  const dir = new_repo()
+  sh_run(dir, "printf 'changed\n' > keep.txt")
+  const base = head_oid(dir)
+  mock_ref_at(OTHER_OID)
+  mock_commit(true)
+  mock_ref_reset()
+  const result = github_commit_worktree(request_for(dir, "worktree", false), options())
+  expect(is_err(result), "stale branch head rejected")
+  const error = unwrap_err(result)
+  assert_eq(error.code, "stale_head", "stale head code")
+  assert_eq(error.category, "conflict", "stale head category")
+  assert_eq(error.expected_head_oid, base, "expected head")
+  assert_eq(error.observed_head_oid, OTHER_OID, "observed head")
+  assert_eq(len(graphql_calls()), 0, "no createCommitOnBranch mutation")
+  const calls = http_mock_calls()
+  assert_eq(len(calls), 1, "only the branch read happened")
+  assert_eq(calls[0].method, "GET", "branch read method")
+  assert_eq(calls[0].url, ref_url(BRANCH), "branch read url")
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+pipeline test_unverified_signature_response_fails_closed(task) {
+  http_mock_clear()
+  const dir = new_repo()
+  sh_run(dir, "printf 'changed\n' > keep.txt")
+  mock_ref_at(head_oid(dir))
+  mock_commit(false)
+  const result = github_commit_worktree(request_for(dir, "worktree", false), options())
+  expect(is_err(result), "unsigned commit rejected")
+  assert_eq(unwrap_err(result).code, "signature_invalid", "signature error code")
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+/**
+ * `createCommitOnBranch` keeps the base tree entry's mode for a path it already
+ * tracks, so editing a tracked executable is publishable. Evidence:
+ * burin-labs/burin-code `9ec6ffb`, committed server-side through that mutation,
+ * carries `:100755 100755 … M scripts/ci-rustc-wrapper.sh`.
+ */
+pipeline test_modifying_a_tracked_executable_is_published_as_a_normal_addition(task) {
+  http_mock_clear()
+  const dir = new_repo()
+  sh_run(dir, "printf '#!/bin/sh\necho changed\n' > tool.sh")
+  const base = head_oid(dir)
+  mock_ref_at(base)
+  mock_commit(true)
+  const result = github_commit_worktree(request_for(dir, "worktree", false), options())
+  expect(!is_err(result), "tracked executable published")
+  const receipt = unwrap(result)
+  assert_eq(change_paths(receipt.changes), ["tool.sh:modified"], "executable change")
+  assert_eq(
+    change_named(receipt.changes, "tool.sh").blob_oid,
+    blob_oid(dir, "tool.sh"),
+    "executable content digest",
+  )
+  const input = graphql_input()
+  assert_eq(field_paths(input.fileChanges.additions), ["tool.sh"], "executable addition")
+  assert_eq(field_paths(input.fileChanges.deletions), [], "no deletions")
+  assert_eq(
+    addition_contents(input, "tool.sh"),
+    base64_encode("#!/bin/sh\necho changed\n"),
+    "executable content",
+  )
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+pipeline test_adding_a_new_executable_is_rejected_before_any_network_request(task) {
+  http_mock_clear()
+  mock_forbid_everything()
+  const dir = new_repo()
+  sh_run(
+    dir,
+    """
+set -e
+printf '#!/bin/sh\necho new\n' > newtool.sh
+chmod 755 newtool.sh
+""",
+  )
+  const result = github_commit_worktree(request_for(dir, "worktree", false), options())
+  expect(is_err(result), "new executable rejected")
+  const error = unwrap_err(result)
+  assert_eq(error.code, "unsupported_new_executable", "new executable error code")
+  assert_eq(error.path, "newtool.sh", "new executable path")
+  assert_eq(error.file_mode, "100755", "new executable mode")
+  assert_eq(error.base_file_mode, "000000", "path absent from the base tree")
+  assert_eq(len(http_mock_calls()), 0, "no network request")
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+pipeline test_renaming_a_tracked_executable_is_rejected_as_a_new_path(task) {
+  http_mock_clear()
+  mock_forbid_everything()
+  const dir = new_repo()
+  sh_run(dir, "mv tool.sh moved-tool.sh")
+  const result = github_commit_worktree(request_for(dir, "worktree", false), options())
+  expect(is_err(result), "renamed executable rejected")
+  const error = unwrap_err(result)
+  assert_eq(error.code, "unsupported_new_executable", "rename destination error code")
+  assert_eq(error.path, "moved-tool.sh", "rename destination path")
+  assert_eq(len(http_mock_calls()), 0, "no network request")
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+pipeline test_a_mode_change_on_an_otherwise_unchanged_file_is_rejected(task) {
+  http_mock_clear()
+  mock_forbid_everything()
+  const dir = new_repo()
+  sh_run(dir, "chmod 755 keep.txt")
+  const result = github_commit_worktree(request_for(dir, "worktree", false), options())
+  expect(is_err(result), "mode change rejected")
+  const error = unwrap_err(result)
+  assert_eq(error.code, "unsupported_mode_change", "mode change error code")
+  assert_eq(error.path, "keep.txt", "mode change path")
+  assert_eq(error.base_file_mode, "100644", "base tree mode")
+  assert_eq(error.file_mode, "100755", "selected mode")
+  assert_eq(len(http_mock_calls()), 0, "no network request")
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+pipeline test_symlink_mode_is_rejected_before_any_network_request(task) {
+  http_mock_clear()
+  mock_forbid_everything()
+  const dir = new_repo()
+  sh_run(dir, "ln -s keep.txt link.txt")
+  const result = github_commit_worktree(request_for(dir, "worktree", false), options())
+  expect(is_err(result), "symlink mode rejected")
+  const error = unwrap_err(result)
+  assert_eq(error.code, "unsupported_file_mode", "symlink error code")
+  assert_eq(error.path, "link.txt", "symlink path")
+  assert_eq(error.file_mode, "120000", "symlink mode")
+  assert_eq(len(http_mock_calls()), 0, "no network request")
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+/**
+ * Writing over a tracked symlink inherits the base tree's `120000` entry, so
+ * the file's bytes would be committed as a link target. Fail closed instead.
+ */
+pipeline test_replacing_a_tracked_symlink_with_a_regular_file_is_rejected(task) {
+  http_mock_clear()
+  mock_forbid_everything()
+  const dir = new_repo()
+  sh_run(dir, "rm tracked-link.txt\nprintf 'now a real file\n' > tracked-link.txt\n")
+  const result = github_commit_worktree(request_for(dir, "worktree", false), options())
+  expect(is_err(result), "symlink replacement rejected")
+  const error = unwrap_err(result)
+  assert_eq(error.code, "unsupported_file_mode", "symlink replacement error code")
+  assert_eq(error.path, "tracked-link.txt", "symlink replacement path")
+  assert_eq(error.base_file_mode, "120000", "base tree symlink mode")
+  assert_eq(len(http_mock_calls()), 0, "no network request")
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+pipeline test_submodule_mode_is_rejected_before_any_network_request(task) {
+  http_mock_clear()
+  mock_forbid_everything()
+  const dir = new_repo()
+  sh_run(
+    dir,
+    """
+set -e
+mkdir nested
+cd nested
+git init -q -b main .
+git config user.email harn-worktree-test@example.test
+git config user.name "Harn Worktree Test"
+git config commit.gpgsign false
+git config core.hooksPath .git/harn-absent-hooks
+printf 'nested\n' > nested.txt
+git add -A
+git commit -q --no-verify -m nested
+""",
+  )
+  const result = github_commit_worktree(request_for(dir, "worktree", false), options())
+  expect(is_err(result), "submodule mode rejected")
+  const error = unwrap_err(result)
+  assert_eq(error.code, "unsupported_file_mode", "submodule error code")
+  assert_eq(error.path, "nested", "submodule path")
+  assert_eq(error.file_mode, "160000", "submodule mode")
+  assert_eq(len(http_mock_calls()), 0, "no network request")
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+pipeline test_adapter_never_mutates_the_caller_index_or_worktree(task) {
+  http_mock_clear()
+  const dir = new_repo()
+  sh_run(
+    dir,
+    """
+set -e
+printf 'hello world\n' > keep.txt
+git add keep.txt
+mv old.txt new.txt
+rm gone.txt
+printf 'untracked\n' > extra.txt
+""",
+  )
+  const base = head_oid(dir)
+  const before = repo_state(dir)
+  mock_ref_at(base)
+  mock_commit(true)
+  const staged = github_worktree_delta({repo_dir: dir, source: "index", base_oid: base})
+  expect(!is_err(staged), "staged delta derived")
+  const derived = github_worktree_delta({repo_dir: dir, source: "worktree", base_oid: base})
+  expect(!is_err(derived), "worktree delta derived")
+  const result = github_commit_worktree(request_for(dir, "worktree", false), options())
+  expect(!is_err(result), "worktree commit succeeded")
+  const after = repo_state(dir)
+  expect_text(after, before, "repository state after publishing")
+  assert_eq(head_oid(dir), base, "local HEAD unchanged")
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+pipeline test_missing_branch_is_created_at_the_base_lease(task) {
+  http_mock_clear()
+  const dir = new_repo()
+  sh_run(dir, "printf 'changed\n' > keep.txt")
+  const base = head_oid(dir)
+  mock_ref_missing()
+  mock_ref_create()
+  mock_commit(true)
+  const result = github_commit_worktree(request_for(dir, "worktree", false), options())
+  expect(!is_err(result), "branch created under the lease")
+  assert_eq(unwrap(result).branch_action, "created", "branch was created")
+  let created = nil
+  for call in http_mock_calls() {
+    if to_string(call.method) == "POST" && to_string(call.url) == refs_url() {
+      created = call
+    }
+  }
+  expect(created != nil, "a branch create request was observed")
+  const body: dict = json_parse(to_string(created.body))
+  assert_eq(body.ref, "refs/heads/" + BRANCH, "created ref")
+  assert_eq(body.sha, base, "created at the base lease")
+  assert_eq(graphql_input().expectedHeadOid, base, "commit leased to the same base")
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+pipeline test_diverged_branch_is_reset_only_when_the_caller_opts_in(task) {
+  http_mock_clear()
+  const dir = new_repo()
+  sh_run(dir, "printf 'changed\n' > keep.txt")
+  const base = head_oid(dir)
+  mock_ref_at(OTHER_OID)
+  mock_ref_reset()
+  mock_commit(true)
+  const result = github_commit_worktree(request_for(dir, "worktree", true), options())
+  expect(!is_err(result), "diverged branch reset under the lease")
+  assert_eq(unwrap(result).branch_action, "reset", "branch was reset")
+  let reset = nil
+  for call in http_mock_calls() {
+    if to_string(call.method) == "PATCH" && to_string(call.url) == ref_update_url(BRANCH) {
+      reset = call
+    }
+  }
+  expect(reset != nil, "a branch reset request was observed")
+  const body: dict = json_parse(to_string(reset.body))
+  assert_eq(body.sha, base, "reset to the base lease")
+  assert_eq(body.force, true, "reset is an explicit force")
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+pipeline test_delta_rejects_an_unknown_selector_source(task) {
+  http_mock_clear()
+  mock_forbid_everything()
+  const dir = new_repo()
+  const result = github_worktree_delta({repo_dir: dir, source: "staged", base_oid: nil})
+  expect(is_err(result), "unknown selector rejected")
+  assert_eq(unwrap_err(result).code, "schema_drift", "selector error code")
+  assert_eq(len(http_mock_calls()), 0, "no network request")
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+pipeline test_commit_rejects_a_branch_name_that_could_escape_the_rest_path(task) {
+  http_mock_clear()
+  mock_forbid_everything()
+  const dir = new_repo()
+  sh_run(dir, "printf 'changed\n' > keep.txt")
+  const result = github_commit_worktree(
+    request_for_branch(dir, "automation/../../settings"),
+    options(),
+  )
+  expect(is_err(result), "unsafe branch rejected")
+  assert_eq(unwrap_err(result).code, "schema_drift", "unsafe branch code")
+  assert_eq(len(http_mock_calls()), 0, "no network request")
+  drop_repo(dir)
+  http_mock_clear()
+}
+
+pipeline test_delta_rejects_a_base_oid_that_is_not_the_local_head(task) {
+  http_mock_clear()
+  mock_forbid_everything()
+  const dir = new_repo()
+  sh_run(dir, "printf 'changed\n' > keep.txt")
+  const result = github_commit_worktree(
+    {
+      owner: OWNER,
+      repo: REPO,
+      branch: BRANCH,
+      headline: "Publish worktree",
+      body: nil,
+      repo_dir: dir,
+      source: "worktree",
+      base_oid: OTHER_OID,
+      create_branch: true,
+      reset_branch: false,
+    },
+    options(),
+  )
+  expect(is_err(result), "mismatched base rejected")
+  const error = unwrap_err(result)
+  assert_eq(error.code, "stale_head", "base mismatch code")
+  assert_eq(error.expected_head_oid, OTHER_OID, "requested base")
+  assert_eq(error.observed_head_oid, head_oid(dir), "local HEAD")
+  assert_eq(len(http_mock_calls()), 0, "no network request")
+  drop_repo(dir)
+  http_mock_clear()
+}


### PR DESCRIPTION
Ships the reusable worktree-to-signed-commit adapter from issue #175 as a new
named export, `harn-github-connector/worktree`. It is the only module in this
package that shells out to `git`; `src/lib.harn` stays a pure HTTP/GraphQL
provider surface and keeps owning the `createCommitOnBranch` mutation. This PR
does **not** cut a release or migrate consumers — those are separate lanes.

## Public API

```harn
import {
  GithubWorktreeCommitReceipt,
  GithubWorktreeCommitRequest,
  GithubWorktreeDelta,
  GithubWorktreeSelector,
  github_commit_worktree,
  github_worktree_delta,
} from "harn-github-connector/worktree"
```

- `github_worktree_delta(selector: GithubWorktreeSelector) -> GithubConnectorResult<GithubWorktreeDelta>`
  derives the typed payload. No network I/O.
- `github_commit_worktree(request: GithubWorktreeCommitRequest, options = nil) -> GithubConnectorResult<GithubWorktreeCommitReceipt>`
  derives, takes the branch lease, publishes through the existing
  `github_create_signed_commit` owner, and returns one receipt.

## Behavior

- **No caller mutation.** `source: "worktree"` (default) stages the full working
  tree into a scratch `GIT_INDEX_FILE` under a temp dir, so untracked
  non-ignored files are included without ever touching the real index.
  `source: "index"` reads the caller's real index read-only.
- **Explicit plumbing.** `git diff-index --cached --raw -z -M --no-abbrev <base>`
  reports both modes, both blob ids, and rename status per entry, so nothing is
  inferred from `--name-only`.
- **Exact bytes.** Content never crosses the Harn string boundary as text:
  `git cat-file blob | base64` produces the payload directly, and the encoded
  length is proven against `git cat-file -s`.
- **Renames** become delete-old plus add-new.
- **Lease.** `base_oid` defaults to, and must equal, the local `HEAD`. The
  branch is created (`create_branch`, default true) or force-reset
  (`reset_branch`, default false) only to that exact base; a diverged head
  otherwise fails closed with `stale_head` before any commit is attempted.
- **Empty delta** returns `committed: false`, `branch_action: "skipped"`, and
  performs no network call at all.

## Deviation from #175's "Transport limits" — please read

#175 says to *"reject every non-`100644` mode"*. That is too strong, and this PR
ships a narrower, evidence-backed rule instead.

`FileAddition` cannot **specify** a mode — #175 is right about that — but the
mutation does **preserve** the base tree entry's mode for a path it already
tracks. Evidence: burin-labs/burin-code `9ec6ffbbea6cb2d99eeaae47be1c5afd19aa7ac7`
has committer `GitHub <noreply@github.com>`, i.e. it was created server-side by
`createCommitOnBranch` from that repo's hand-rolled bump workflow, and its raw
`git diff-tree -r` output contains:

```
:100755 100755 4d377e6d… 545f0a7f… M	scripts/check-ci-script-contracts.sh
:100755 100755 eb691a76… 127753ce… M	scripts/ci-rustc-wrapper.sh
```

Both sides are `100755`. A blanket reject would therefore refuse cases the
transport handles correctly. That matters concretely: burin-code tracks 161
executables (94 directly under `scripts/`), and its PR agent commits an
arbitrary agent worktree, so a blanket rule would turn "an agent edited a shell
script" into a hard failure on a path that works today.

The rule this PR implements, still fully fail-closed and still entirely
pre-network and pre-mutation, keyed on the base-tree mode that
`git diff-index --raw` reports on the source side:

| Case | Outcome |
|---|---|
| Tracked `100755` edited, mode unchanged | published; GitHub keeps `100755` |
| New path with mode `100755` (added, copied, or a rename destination) | `unsupported_new_executable` |
| Mode changes between base tree and selected state (either direction) | `unsupported_mode_change` |
| Symlink `120000` or submodule `160000` on **either** side | `unsupported_file_mode` |
| Deletion of any mode | supported (deletions carry no mode) |

Two notes on the edges:

- The **new-executable** rejection is *not* empirically confirmed — a committed
  tree keeps no record of what the author intended, so nothing in history
  distinguishes it. Mechanically there is no prior entry to inherit from, so it
  would land `100644`. It fails closed, and the code comment says so explicitly.
- Symlink rejection covers **both** directions, including writing a regular file
  over a path the base tree holds at `120000`: that write would inherit `120000`
  and commit the file's bytes as a link target. Rejecting this is a bug fix
  relative to shell implementations that use `test -f` (which follows symlinks).

Errors carry `path`, `file_mode`, and `base_file_mode` as typed evidence.

## Tests

`tests/worktree_commit.harn` — 19 pipelines, real temporary Git repositories
created with real `git init`/`add`/`commit`, mocking only GitHub's HTTP
boundary. Assertions inspect the observed GraphQL request and the returned typed
receipt; there are no source-substring assertions.

| Acceptance bullet | Test |
|---|---|
| modified / added / deleted, rename, empty file | `test_worktree_commit_publishes_modified_added_deleted_and_renamed_paths` |
| binary bytes survive exactly | `test_worktree_commit_preserves_exact_binary_bytes` (decodes the observed base64 and `cmp`s it against the original file) |
| staged-only vs worktree | `test_index_selector_publishes_only_staged_changes` |
| empty delta | `test_empty_delta_is_a_clean_outcome_with_no_network_call` |
| stale branch head, no mutation | `test_stale_branch_head_fails_closed_before_any_mutation` |
| invalid signature | `test_unverified_signature_response_fails_closed` |
| tracked executable accepted | `test_modifying_a_tracked_executable_is_published_as_a_normal_addition` |
| new executable rejected | `test_adding_a_new_executable_is_rejected_before_any_network_request` |
| rename destination is a new path | `test_renaming_a_tracked_executable_is_rejected_as_a_new_path` |
| mode flip rejected | `test_a_mode_change_on_an_otherwise_unchanged_file_is_rejected` |
| symlink rejected | `test_symlink_mode_is_rejected_before_any_network_request`, `test_replacing_a_tracked_symlink_with_a_regular_file_is_rejected` |
| submodule rejected | `test_submodule_mode_is_rejected_before_any_network_request` |
| no caller index/worktree mutation | `test_adapter_never_mutates_the_caller_index_or_worktree` (compares `git rev-parse HEAD` + `git status --porcelain` + `git ls-files -s` before and after) |
| branch lease | `test_missing_branch_is_created_at_the_base_lease`, `test_diverged_branch_is_reset_only_when_the_caller_opts_in`, `test_delta_rejects_a_base_oid_that_is_not_the_local_head` |
| input validation | `test_delta_rejects_an_unknown_selector_source`, `test_commit_rejects_a_branch_name_that_could_escape_the_rest_path` |

Every rejection test also asserts `len(http_mock_calls()) == 0`.

Both the binary round-trip and the no-mutation proof were verified to fail when
deliberately broken (comparing against the wrong file; using the real index
instead of the scratch one), so they are not vacuous.

## Incidental fix

`__github_signed_commit_additions` treated an empty `contents_base64` the same
as a missing one, so a zero-byte file was unpublishable. It now distinguishes
absent from empty.

## Contract note for the migration lane

String-literal union types do not survive a cross-package import: a consumer
writing `{source: "worktree"}` against a `"worktree" | "index"` field fails
`harn check`. Closed value sets are therefore carried as `string` and validated
at runtime, with the allowed values documented on each type. Consumers must
import the type name itself (and any nested record type they construct) for
record literals to coerce.

## Checks

`harn fmt --check src tests`, `harn check src`, `harn check --strict-types src`,
`harn lint src`, `harn run` over every `tests/*.harn`, `harn test tests --parallel`
(82 passed), `harn connector check .`, and the CI package-install smoke against
`HEAD` extended to import both `harn-github-connector/default` and
`harn-github-connector/worktree`.

## Still open on #175

- publish connector v0.4.x (latest tag is still v0.3.0)
- migrate the consumer workflows and delete their local `createCommitOnBranch`
  payload builders, including the duplicate inline-Python ones

Refs #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-github-connector/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787592852&installation_model_id=426921&pr_number=194&repository=burin-labs%2Fharn-github-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-github-connector%2Fpull%2F194&signature=69d8b545059d963a49c49a0f4ee93419871da337bce6337a763d097226814f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->