### PR TITLE
Add a publish CLI export so consumers stop rewriting the front end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,12 +114,26 @@ jobs:
             GithubConnectorResult,
             GithubReleaseLookup,
           } from "harn-github-connector/default"
+          import { GithubWorktreeCommitRequest, github_commit_worktree } from "harn-github-connector/worktree"
+          import { publish_main } from "harn-github-connector/publish"
 
           fn release_state(result: GithubConnectorResult<GithubReleaseLookup>) -> string {
             if is_err(result) {
               return unwrap_err(result).code
             }
             return unwrap(result).state
+          }
+
+          // Every declared export must resolve from a real consumer, not just from
+          // inside this package. `worktree` and `publish` were added after the smoke was
+          // written, and a missing `[exports]` entry is invisible to `harn check src`.
+          fn commit(request: GithubWorktreeCommitRequest) {
+            return github_commit_worktree(request)
+          }
+
+          // The exact entry file the README tells consumers to write.
+          fn main(harness: Harness) {
+            exit(publish_main(harness, argv ?? []))
           }
           EOF
           harn check smoke.harn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- Add a `harn-github-connector/publish` export: a command-line front end for
+  `github_commit_worktree` owning argument parsing, usage text, the changed-path
+  summary a CI step appends to its job log, and exit codes that separate a bad
+  invocation (`2`) from a failed publish (`1`). Consumers keep only a one-line
+  entry file, so a repository adopting the adapter no longer has to write its
+  own argument parser. `--no-reset` opts out of force-moving a branch that is
+  not already at the base commit.
+
 ## 0.4.0 - 2026-07-25
 
 - Add typed `github.pr.edit` and `pulls.update` operations for a closed set of

--- a/README.md
+++ b/README.md
@@ -329,6 +329,51 @@ Behavior worth knowing before you use it:
 - A branch head that differs from the lease fails with `stale_head` unless
   `reset_branch` is set.
 
+### Publishing from CI
+
+`harn-github-connector/publish` is a command-line front end for the adapter, so
+a workflow does not have to hand-roll argument parsing, a step summary, and
+exit codes around it. Harn packages export modules rather than commands, so a
+consumer keeps one entry file for `harn run` to target:
+
+```harn,ignore
+import { publish_main } from "harn-github-connector/publish"
+
+fn main(harness: Harness) {
+  exit(publish_main(harness, argv ?? []))
+}
+```
+
+```bash
+harn run --no-sandbox scripts/signed-commit/publish.harn -- \
+  --repo octo-org/octo-repo \
+  --branch automation/bump \
+  --headline "Bump the pinned runtime" \
+  --source index
+```
+
+`--no-sandbox` is required: the adapter shells out to `git` plumbing, writes a
+scratch index outside the checkout, and calls the GitHub API.
+
+| Flag | Meaning |
+|---|---|
+| `--repo` | Target repository as `owner/repo`. Required. |
+| `--branch` | Automation branch to create or reset onto the base commit. Required. |
+| `--headline` | Commit headline. Required. |
+| `--body` | Optional commit body. An absent body stays absent, not empty. |
+| `--repo-dir` | Checkout to read from. Defaults to the current directory. |
+| `--source` | `worktree` (default) or `index`. |
+| `--no-reset` | Fail instead of force-moving a branch that is not at the base commit. |
+
+Exit status is `0` published, `1` the publish failed, `2` the invocation was
+wrong — so a CI step can tell a broken workflow edit apart from a GitHub-side
+failure. An empty delta exits `1` rather than reporting success for a commit
+that was never made; callers that stage their own change have already
+established there is something to publish.
+
+Credentials are the connector's contract: set `GITHUB_INSTALLATION_TOKEN`, or
+`GITHUB_APP_ID` + `GITHUB_INSTALLATION_ID` with a private key.
+
 ## GitHub App setup
 
 Create a GitHub App and install it into the target account or repository set.

--- a/harn.toml
+++ b/harn.toml
@@ -9,6 +9,7 @@ harn = ">=0.10,<0.11"
 [exports]
 default = "src/lib.harn"
 worktree = "src/worktree_commit.harn"
+publish = "src/publish_cli.harn"
 
 [[providers]]
 id = "github"

--- a/scripts/check-release.sh
+++ b/scripts/check-release.sh
@@ -81,12 +81,26 @@ import {
   GithubConnectorResult,
   GithubReleaseLookup,
 } from "harn-github-connector/default"
+import { GithubWorktreeCommitRequest, github_commit_worktree } from "harn-github-connector/worktree"
+import { publish_main } from "harn-github-connector/publish"
 
 fn release_state(result: GithubConnectorResult<GithubReleaseLookup>) -> string {
   if is_err(result) {
     return unwrap_err(result).code
   }
   return unwrap(result).state
+}
+
+// Every declared export must resolve from a real consumer, not just from
+// inside this package. `worktree` and `publish` were added after the smoke was
+// written, and a missing `[exports]` entry is invisible to `harn check src`.
+fn commit(request: GithubWorktreeCommitRequest) {
+  return github_commit_worktree(request)
+}
+
+// The exact entry file the README tells consumers to write.
+fn main(harness: Harness) {
+  exit(publish_main(harness, argv ?? []))
 }
 EOF
 harn check smoke.harn

--- a/src/publish_cli.harn
+++ b/src/publish_cli.harn
@@ -1,0 +1,208 @@
+/**
+ * Command-line front end for `github_commit_worktree`.
+ *
+ * `src/worktree_commit.harn` owns turning an exact local Git state into one
+ * signed commit. This module owns the other half every consumer was otherwise
+ * writing for itself: flag parsing, usage text, the summary a CI step appends
+ * to its job log, and the exit codes that distinguish a bad invocation from a
+ * failed publish.
+ *
+ * Consumers keep a single entry file:
+ *
+ *     import { publish_main } from "harn-github-connector/publish"
+ *
+ *     fn main(harness: Harness) {
+ *       exit(publish_main(harness, argv ?? []))
+ *     }
+ *
+ * That exists because Harn packages export modules, not commands, so a
+ * consumer still needs a local file for `harn run` to target. Everything
+ * behind it lives here, which is the point: four repositories were about to
+ * grow four copies of the same argument parser.
+ *
+ * Credentials are the connector's contract, not this module's — set
+ * `GITHUB_INSTALLATION_TOKEN`, or `GITHUB_APP_ID` + `GITHUB_INSTALLATION_ID`
+ * with a private key.
+ */
+import {
+  GithubWorktreeCommitReceipt,
+  GithubWorktreeCommitRequest,
+  github_commit_worktree,
+} from "./worktree_commit"
+
+pub const PUBLISH_USAGE =
+  """Publish a local Git state to a GitHub branch as one GitHub-signed commit.
+
+  --repo      Target repository as `owner/repo`. Required.
+  --branch    Automation branch to create or reset onto the base commit. Required.
+  --headline  Commit headline. Required.
+  --body      Optional commit body.
+  --repo-dir  Checkout to read the change from. Defaults to the current directory.
+  --source    `worktree` (default) commits tracked edits plus untracked files;
+              `index` commits exactly what is staged.
+  --no-reset  Fail instead of force-moving a branch that is not already at the
+              base commit."""
+
+/** Flags taking one value, mapped to the request field they populate. */
+const PUBLISH_VALUE_FLAGS = {
+  "--repo": "repo",
+  "--branch": "branch",
+  "--headline": "headline",
+  "--body": "body",
+  "--repo-dir": "repo_dir",
+  "--source": "source",
+}
+
+const PUBLISH_BOOL_FLAGS = {"--no-reset": "no_reset"}
+
+const PUBLISH_REQUIRED_FLAGS = ["--repo", "--branch", "--headline"]
+
+/**
+ * Parse `--flag value` pairs into request fields.
+ *
+ * Rejections come back as values rather than exits so the whole parse stays a
+ * pure function; `publish_main` owns usage output and exit codes.
+ */
+pub fn parse_publish_args(args: list<string>) -> Result<dict, string> {
+  let values = {}
+  let i = 0
+  while i < len(args) {
+    const token = args[i] ?? ""
+    const flag = PUBLISH_BOOL_FLAGS.get(token)
+    if flag != nil {
+      values[flag] = "true"
+      i = i + 1
+      continue
+    }
+    const field = PUBLISH_VALUE_FLAGS.get(token)
+    if field == nil {
+      return Err("unrecognized argument " + token)
+    }
+    if i + 1 >= len(args) {
+      return Err(token + " expects a value")
+    }
+    if values.get(field) != nil {
+      return Err(token + " was given more than once")
+    }
+    values[field] = args[i + 1] ?? ""
+    i = i + 2
+  }
+  for flag in PUBLISH_REQUIRED_FLAGS {
+    const field = PUBLISH_VALUE_FLAGS.get(flag) ?? ""
+    if trim(to_string(values.get(field) ?? "")) == "" {
+      return Err(flag + " is required")
+    }
+  }
+  const slug = to_string(values.get("repo") ?? "")
+  const owner_repo = split(slug, "/")
+  if len(owner_repo) != 2 || owner_repo[0] == "" || owner_repo[1] == "" {
+    return Err("--repo expects `owner/repo`, got " + slug)
+  }
+  values["owner"] = owner_repo[0]
+  values["repo"] = owner_repo[1]
+  return Ok(values)
+}
+
+/**
+ * Build the typed request.
+ *
+ * `reset_branch` defaults on because these branches are disposable automation
+ * refs re-derived from the base commit on every run: a leftover branch from a
+ * previous run is stale by construction, not a conflict worth preserving.
+ * `--no-reset` is for callers that treat a moved branch as someone else's work.
+ */
+pub fn publish_request(values: dict) -> GithubWorktreeCommitRequest {
+  const body = to_string(values.get("body") ?? "")
+  const request: GithubWorktreeCommitRequest = {
+    owner: to_string(values.get("owner") ?? ""),
+    repo: to_string(values.get("repo") ?? ""),
+    branch: to_string(values.get("branch") ?? ""),
+    headline: to_string(values.get("headline") ?? ""),
+    body: if body == "" {
+      nil
+    } else {
+      body
+    },
+    repo_dir: to_string(values.get("repo_dir") ?? "."),
+    source: values.get("source"),
+    create_branch: true,
+    reset_branch: values.get("no_reset") == nil,
+  }
+  return request
+}
+
+/** Markdown summary of a receipt, one line per changed path. */
+pub fn describe_receipt(receipt: GithubWorktreeCommitReceipt) -> list<string> {
+  const headline = join(
+    [
+      "Created signed commit `" + receipt.commit_oid + "`",
+      "on `" + receipt.branch + "` of `" + receipt.repository + "`",
+      "(branch " + receipt.branch_action + ",",
+      "base " + receipt.base_oid + ",",
+      "signature " + receipt.signature.state + ").",
+    ],
+    " ",
+  )
+  let lines = [headline, ""]
+  for change in receipt.changes {
+    lines = lines + ["- " + change.status + " `" + change.path + "`"]
+  }
+  lines = lines + ["", receipt.commit_url]
+  return lines
+}
+
+fn publish_parsed(harness: Harness, values: dict) -> int {
+  const result = github_commit_worktree(publish_request(values))
+  if is_err(result) {
+    const failure = unwrap_err(result)
+    harness.stdio.eprintln(
+      "signed commit failed [" + to_string(failure.code) + "]: " + to_string(failure.message),
+    )
+    return 1
+  }
+  const receipt: GithubWorktreeCommitReceipt = unwrap(result)
+  if !receipt.committed {
+    // Callers stage or verify their change before invoking this, so an empty
+    // delta means it was lost between those two steps. Reporting success would
+    // leave a branch that silently has nothing on it.
+    const repo_dir = to_string(values.get("repo_dir") ?? ".")
+    harness.stdio.eprintln(
+      "no file changes found in `" + receipt.source + "` of " + repo_dir
+        + "; refusing to report success for a commit that was never made",
+    )
+    return 1
+  }
+  for line in describe_receipt(receipt) {
+    harness.stdio.println(line)
+  }
+  return 0
+}
+
+/**
+ * Run the publish command.
+ *
+ * Returns the process exit status: 0 published, 1 the publish failed, 2 the
+ * invocation was wrong. Separating 2 from 1 is what lets a CI step tell a
+ * broken workflow edit apart from a GitHub-side failure.
+ */
+pub fn publish_main(harness: Harness, args: list<string>) -> int {
+  if contains(args, "-h") || contains(args, "--help") {
+    harness.stdio.println(PUBLISH_USAGE)
+    return 0
+  }
+  const parsed = parse_publish_args(args)
+  if is_err(parsed) {
+    harness.stdio.eprintln(PUBLISH_USAGE)
+    harness.stdio.eprintln("error: " + to_string(unwrap_err(parsed)))
+    return 2
+  }
+  const values: dict = unwrap(parsed)
+  const result = try {
+    publish_parsed(harness, values)
+  }
+  if is_err(result) {
+    harness.stdio.eprintln("signed commit failed: " + to_string(unwrap_err(result)))
+    return 1
+  }
+  return to_int(unwrap(result))
+}

--- a/tests/publish_cli.harn
+++ b/tests/publish_cli.harn
@@ -1,0 +1,167 @@
+// Tests for src/publish_cli.harn.
+//
+// Argument parsing, request construction and summary rendering are pure, so
+// they are exercised directly. Deriving a delta and publishing it belong to
+// `github_commit_worktree` and are covered by tests/worktree_commit.harn.
+import { describe_receipt, parse_publish_args, publish_request } from "../src/publish_cli"
+import {
+  GithubWorktreeChange,
+  GithubWorktreeCommitReceipt,
+  GithubWorktreeSignature,
+} from "../src/worktree_commit"
+
+const MINIMAL = ["--repo", "octo-org/octo-repo", "--branch", "automation/x", "--headline", "Update"]
+
+fn parsed(args: list<string>) -> dict {
+  const result = parse_publish_args(args)
+  if is_err(result) {
+    throw "expected a successful parse, got: " + to_string(unwrap_err(result))
+  }
+  const values: dict = unwrap(result)
+  return values
+}
+
+fn parse_error(args: list<string>) -> string {
+  const result = parse_publish_args(args)
+  if !is_err(result) {
+    throw "expected a rejected parse, got: " + json_stringify(unwrap(result))
+  }
+  return to_string(unwrap_err(result))
+}
+
+pipeline test_publish_args_split_the_repository_slug(task) {
+  const values = parsed(MINIMAL)
+  assert_eq(values.get("owner"), "octo-org")
+  assert_eq(values.get("repo"), "octo-repo")
+  assert_eq(values.get("branch"), "automation/x")
+  assert_eq(values.get("headline"), "Update")
+}
+
+pipeline test_publish_args_reject_unusable_input(task) {
+  // Each case pairs an argument list with a fragment its rejection must name,
+  // so a parser that fails for the wrong reason still fails the test.
+  const cases = [
+    {args: [], want: "--repo is required"},
+    {args: ["--repo", "octo-org/octo-repo"], want: "--branch is required"},
+    {args: ["--repo", "octo-org/octo-repo", "--branch", "b"], want: "--headline is required"},
+    {
+      args: ["--repo", "octo-org/octo-repo", "--branch", " ", "--headline", "h"],
+      want: "--branch is required",
+    },
+    {args: MINIMAL + ["--source"], want: "--source expects a value"},
+    {args: MINIMAL + ["--nope", "x"], want: "unrecognized argument --nope"},
+    {args: MINIMAL + ["--branch", "other"], want: "--branch was given more than once"},
+    {args: MINIMAL + ["extra"], want: "unrecognized argument extra"},
+    {
+      args: ["--repo", "octo-repo", "--branch", "b", "--headline", "h"],
+      want: "expects `owner/repo`",
+    },
+    {args: ["--repo", "a/b/c", "--branch", "b", "--headline", "h"], want: "expects `owner/repo`"},
+    {
+      args: ["--repo", "/octo-repo", "--branch", "b", "--headline", "h"],
+      want: "expects `owner/repo`",
+    },
+  ]
+  for case in cases {
+    const message = parse_error(case.args)
+    assert_eq(contains(message, case.want), true, message)
+  }
+}
+
+pipeline test_publish_request_leaves_adapter_defaults_alone(task) {
+  const request = publish_request(parsed(MINIMAL))
+  assert_eq(request.owner, "octo-org")
+  assert_eq(request.repo, "octo-repo")
+  assert_eq(request.branch, "automation/x")
+  assert_eq(request.headline, "Update")
+  // A nil source means `worktree` and a nil base_oid means local HEAD, both
+  // decided by the adapter. Restating them here would be a second place for
+  // those defaults to live.
+  assert_eq(request.source, nil)
+  assert_eq(request.repo_dir, ".")
+  // An absent body must not become an empty-string body: the mutation only
+  // omits `message.body` when it is blank, and a caller reading the request
+  // should see "no body", not "empty body".
+  assert_eq(request.body, nil)
+  assert_eq(request.create_branch, true)
+  assert_eq(request.reset_branch, true)
+}
+
+pipeline test_publish_request_carries_every_optional_flag(task) {
+  const optional = [
+    "--body",
+    "Published by automation: https://example.test/r/1",
+    "--repo-dir",
+    "upstream",
+    "--source",
+    "index",
+  ]
+  const request = publish_request(parsed(MINIMAL + optional))
+  assert_eq(request.body, "Published by automation: https://example.test/r/1")
+  assert_eq(request.repo_dir, "upstream")
+  assert_eq(request.source, "index")
+  assert_eq(request.reset_branch, true)
+}
+
+pipeline test_no_reset_opts_out_of_force_moving_the_branch(task) {
+  const request = publish_request(parsed(MINIMAL + ["--no-reset"]))
+  assert_eq(request.reset_branch, false)
+  // Creating a missing branch is still allowed: --no-reset is about refusing to
+  // move someone else's commits, not about requiring the branch to pre-exist.
+  assert_eq(request.create_branch, true)
+}
+
+pipeline test_summary_names_the_commit_and_every_changed_path(task) {
+  const change: GithubWorktreeChange = {
+    path: "Formula/burin.rb",
+    status: "modified",
+    blob_oid: "1111111111111111111111111111111111111111",
+    size_bytes: 12,
+    rename_from: nil,
+    rename_to: nil,
+  }
+  const dropped: GithubWorktreeChange = {
+    path: "Casks/old.rb",
+    status: "deleted",
+    blob_oid: "2222222222222222222222222222222222222222",
+    size_bytes: 0,
+    rename_from: nil,
+    rename_to: nil,
+  }
+  const signature: GithubWorktreeSignature = {
+    verified: true,
+    signed_by_github: true,
+    state: "VALID",
+  }
+  const receipt: GithubWorktreeCommitReceipt = {
+    repository: "octo-org/octo-repo",
+    owner: "octo-org",
+    repo: "octo-repo",
+    branch: "automation/x",
+    source: "worktree",
+    base_oid: "3333333333333333333333333333333333333333",
+    committed: true,
+    commit_oid: "4444444444444444444444444444444444444444",
+    commit_url:
+      "https://github.com/octo-org/octo-repo/commit/4444444444444444444444444444444444444444",
+    branch_action: "reset",
+    changes: [change, dropped],
+    signature: signature,
+  }
+  const summary = join(describe_receipt(receipt), "\n")
+  // The hand-rolled builders this replaces printed the oid alone, so a receipt
+  // that lost its paths or its signature evidence still read as clean success.
+  for fragment in [
+    receipt.commit_oid,
+    receipt.base_oid,
+    receipt.branch,
+    receipt.repository,
+    receipt.commit_url,
+    "reset",
+    "VALID",
+    "- modified `Formula/burin.rb`",
+    "- deleted `Casks/old.rb`",
+  ] {
+    assert_eq(contains(summary, fragment), true, summary)
+  }
+}


### PR DESCRIPTION
## Summary

#194 gave the fleet one owner for turning a local Git state into a signed
commit — but only for the *call*. Every consumer still had to write the other
half itself: flag parsing, usage text, the changed-path summary its CI step
appends to the job log, and exit codes.

harn-cloud wrote exactly that shim to adopt the adapter
(burin-labs/harn-cloud#1362), and burin-code's four remaining sites plus any
future consumer were each about to write the same ~150 lines again. That is the
duplication #175 set out to remove, just moved one layer up.

`harn-github-connector/publish` moves it into the package. Harn packages export
modules rather than commands, so a consumer still needs one file for `harn run`
to target — but it is now four lines:

```harn
import { publish_main } from "harn-github-connector/publish"

fn main(harness: Harness) {
  exit(publish_main(harness, argv ?? []))
}
```

## Design notes

- `publish_main` **returns** a status instead of exiting, and `parse_publish_args`
  returns errors as values, so the entire surface is testable without spawning a
  subprocess.
- Exit codes separate **a bad invocation (`2`) from a failed publish (`1`)** —
  that is what lets a CI step tell a broken workflow edit apart from a
  GitHub-side failure.
- `--no-reset` is new: it opts out of force-moving a branch that is not already
  at the base commit, for callers that treat a moved branch as someone else's
  work rather than as stale automation output. The default stays `reset`,
  matching how every current consumer uses disposable automation refs.
- An empty delta exits `1` rather than reporting success for a commit that was
  never made.

## The smoke change is not decoration

The consumer install smoke now imports **every** declared export and includes
the exact entry file the README documents.

`harn check src` cannot see a missing `[exports]` entry — `worktree` was added
in #194 without the smoke ever covering it. This change's own first smoke run
failed with `unresolved import 'harn-github-connector/publish'`, because
`harn add <path>@HEAD` packages the *committed* tree and the manifest edit was
still uncommitted. That is precisely the class of mistake the smoke should
catch, and now does.

## Verification

`harn check src`, `harn lint src`, `harn fmt --check src tests`, **88/88 tests**
(82 + 6 new).

End-to-end through a real consumer entry file against `burin-labs/harn-cloud`
on a scratch branch (deleted afterwards):

| case | result |
| --- | --- |
| success | commit `119d4fdd`, `verification.verified: true`, `reason: valid`, expected parent, `PROBE.md` only |
| `--no-reset` on a moved branch | `stale_head`, exit **1** |
| default reset on that same branch | republished, `branch_action: reset` |
| `--help` | usage, exit **0** |
| malformed `--repo` / missing required flag | exit **2** |
| empty delta | exit **1**, names the source and repo dir |

## Follow-ups

Once this releases, harn-cloud's shim collapses to the four-line entry file, and
burin-code's four hand-rolled builders (`bump-harn.yml`, `bump-homebrew.yml`,
`bump-scoop.yml`, `scripts/github-pr-agent.sh`) can migrate onto the same entry
without any of them growing an argument parser.

Refs #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-github-connector/pr/196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787595825&installation_model_id=426921&pr_number=196&repository=burin-labs%2Fharn-github-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-github-connector%2Fpull%2F196&signature=aa94221ab2120edae04fc9ea42890e1955570a1c5de04ec95161de8eebf323c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->